### PR TITLE
test: use the additional test vectors from C2SP/Wycheproof

### DIFF
--- a/.github/workflows/test-wycheproof.yml
+++ b/.github/workflows/test-wycheproof.yml
@@ -1,0 +1,20 @@
+name: Wycheproof vectors
+on:
+  - push
+  - pull_request
+permissions:
+  contents: read
+jobs:
+  wycheproof:
+    name: ML-KEM & ML-DSA Wycheproof
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
+        with:
+          cache: npm
+          node-version: 22
+      - run: npm install
+      - run: npm run test:wycheproof

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 *.d.ts.map
 /test/build
 /test/compiled
+/test/vectors/wycheproof

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test:bun": "bun test/index.ts",
     "test:deno": "deno --allow-env --allow-read test/index.ts",
     "test:node20": "cd test; npx tsc; node compiled/test/index.js",
-    "test:slow": "SLOW_TESTS=1 node test/index.ts"
+    "test:slow": "SLOW_TESTS=1 node test/index.ts",
+    "test:wycheproof": "bash test/fetch-wycheproof.sh && node --experimental-strip-types --no-warnings test/wycheproof.test.ts"
   },
   "exports": {
     ".": "./index.js",

--- a/test/fetch-wycheproof.sh
+++ b/test/fetch-wycheproof.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+# Fetches Wycheproof test vectors from C2SP/wycheproof and gzips them.
+# Run before test:wycheproof.
+
+DIR="$(cd "$(dirname "$0")" && pwd)/vectors/wycheproof"
+BASE="https://raw.githubusercontent.com/C2SP/wycheproof/master/testvectors_v1"
+
+FILES=(
+  mlkem_512_keygen_seed_test
+  mlkem_512_test
+  mlkem_512_encaps_test
+  mlkem_768_keygen_seed_test
+  mlkem_768_test
+  mlkem_768_encaps_test
+  mlkem_1024_keygen_seed_test
+  mlkem_1024_test
+  mlkem_1024_encaps_test
+  mldsa_44_verify_test
+  mldsa_44_sign_seed_test
+  mldsa_65_verify_test
+  mldsa_65_sign_seed_test
+  mldsa_87_verify_test
+  mldsa_87_sign_seed_test
+)
+
+mkdir -p "$DIR"
+
+for f in "${FILES[@]}"; do
+  dest="$DIR/${f}.json.gz"
+  if [ -f "$dest" ]; then
+    echo "skip $f (cached)"
+    continue
+  fi
+  echo "fetch $f"
+  curl -sfL "${BASE}/${f}.json" | gzip > "$dest"
+done
+
+echo "done: $(find "$DIR" -name '*.json.gz' | wc -l | tr -d ' ') vector files"

--- a/test/index.ts
+++ b/test/index.ts
@@ -3,6 +3,7 @@ import './acvp.test.ts';
 import './basic.test.ts';
 import './falcon.test.ts';
 import './hybrid.test.ts';
+// import './wycheproof.test.ts'; // run separately: npm run test:wycheproof
 // import './errors.test.ts';
 
 should.runWhen(import.meta.url);

--- a/test/wycheproof.test.ts
+++ b/test/wycheproof.test.ts
@@ -1,0 +1,154 @@
+// Wycheproof test vectors from https://github.com/C2SP/wycheproof
+import { hexToBytes as hexx } from '@noble/hashes/utils.js';
+import { describe, should } from '@paulmillr/jsbt/test.js';
+import { deepStrictEqual as eql } from 'node:assert';
+import { ml_dsa44, ml_dsa65, ml_dsa87 } from '../src/ml-dsa.ts';
+import { ml_kem1024, ml_kem512, ml_kem768 } from '../src/ml-kem.ts';
+import { jsonGZ } from './util.ts';
+
+const loadWP = (name) => jsonGZ(`vectors/wycheproof/${name}.json.gz`);
+
+const KEM_LEVELS = [
+  { level: '512', kem: ml_kem512 },
+  { level: '768', kem: ml_kem768 },
+  { level: '1024', kem: ml_kem1024 },
+];
+
+const DSA_LEVELS = [
+  { level: '44', dsa: ml_dsa44 },
+  { level: '65', dsa: ml_dsa65 },
+  { level: '87', dsa: ml_dsa87 },
+];
+
+function dsaSign(dsa, secretKey, t) {
+  if (t.flags?.includes('Internal')) {
+    return dsa.internal.sign(hexx(t.mu), secretKey, {
+      externalMu: true,
+      extraEntropy: false,
+    });
+  }
+  const opts = {
+    extraEntropy: false,
+    context: t.ctx !== undefined ? hexx(t.ctx) : undefined,
+  };
+  return dsa.sign(hexx(t.msg), secretKey, opts);
+}
+
+describe('Wycheproof', () => {
+  describe('ML-KEM', () => {
+    for (const { level, kem } of KEM_LEVELS) {
+      describe(`ML-KEM-${level}`, () => {
+        should('keygen', () => {
+          const data = loadWP(`mlkem_${level}_keygen_seed_test`);
+          for (const g of data.testGroups) {
+            for (const t of g.tests) {
+              const keys = kem.keygen(hexx(t.seed));
+              eql(keys.publicKey, hexx(t.ek));
+              if (t.dk) eql(keys.secretKey, hexx(t.dk));
+            }
+          }
+        });
+        should('decaps', () => {
+          const data = loadWP(`mlkem_${level}_test`);
+          for (const g of data.testGroups) {
+            for (const t of g.tests) {
+              if (t.result === 'valid') {
+                const keys = kem.keygen(hexx(t.seed));
+                eql(keys.publicKey, hexx(t.ek));
+                const ss = kem.decapsulate(hexx(t.c), keys.secretKey);
+                eql(ss, hexx(t.K));
+              } else {
+                let threw = false;
+                try {
+                  const keys = kem.keygen(hexx(t.seed));
+                  kem.decapsulate(hexx(t.c), keys.secretKey);
+                } catch {
+                  threw = true;
+                }
+                eql(threw, true);
+              }
+            }
+          }
+        });
+        should('encaps', () => {
+          const data = loadWP(`mlkem_${level}_encaps_test`);
+          for (const g of data.testGroups) {
+            for (const t of g.tests) {
+              if (t.result === 'valid') {
+                const res = kem.encapsulate(hexx(t.ek), hexx(t.m));
+                eql(res.cipherText, hexx(t.c));
+                eql(res.sharedSecret, hexx(t.K));
+              } else {
+                let threw = false;
+                try {
+                  kem.encapsulate(hexx(t.ek), hexx(t.m));
+                } catch {
+                  threw = true;
+                }
+                eql(threw, true);
+              }
+            }
+          }
+        });
+        // semi_expanded_decaps tests skipped: not applicable
+        // (provide semi-expanded dk, not keygen seeds)
+      });
+    }
+  });
+  describe('ML-DSA', () => {
+    for (const { level, dsa } of DSA_LEVELS) {
+      describe(`ML-DSA-${level}`, () => {
+        should('verify', () => {
+          const data = loadWP(`mldsa_${level}_verify_test`);
+          for (const g of data.testGroups) {
+            const pk = hexx(g.publicKey);
+            for (const t of g.tests) {
+              const ctx = t.ctx !== undefined ? hexx(t.ctx) : undefined;
+              const opts = ctx !== undefined ? { context: ctx } : {};
+              let valid;
+              try {
+                valid = dsa.verify(hexx(t.sig), hexx(t.msg), pk, opts);
+              } catch {
+                valid = false;
+              }
+              if (t.result === 'valid') eql(valid, true);
+              else if (t.result === 'invalid') eql(valid, false);
+            }
+          }
+        });
+        should('sign (from seed)', () => {
+          const data = loadWP(`mldsa_${level}_sign_seed_test`);
+          for (const g of data.testGroups) {
+            let keys;
+            try {
+              keys = dsa.keygen(hexx(g.privateSeed));
+            } catch {
+              // Invalid seed length: all tests in group must be invalid
+              for (const t of g.tests) eql(t.result, 'invalid');
+              continue;
+            }
+            eql(keys.publicKey, hexx(g.publicKey));
+            for (const t of g.tests) {
+              if (t.result === 'valid') {
+                const sig = dsaSign(dsa, keys.secretKey, t);
+                eql(sig, hexx(t.sig));
+              } else {
+                let threw = false;
+                try {
+                  dsaSign(dsa, keys.secretKey, t);
+                } catch {
+                  threw = true;
+                }
+                eql(threw, true);
+              }
+            }
+          }
+        });
+        // sign_noseed tests skipped: not applicable
+        // (provide semi-expanded private keys, not seeds)
+      });
+    }
+  });
+});
+
+should.runWhen(import.meta.url);


### PR DESCRIPTION
This adds a CI workflow that fetches the latest test vectors from [Project Wycheproof](https://github.org/C2SP/Wycheproof).