### PR TITLE
test: Add smoke-test for depending on Chrome's WebCrypto PQC impl

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,41 @@
+name: Playwright PQC Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. Grab your repository's code
+      - uses: actions/checkout@v4
+
+      # 2. Set up the Node environment
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20 # Or whatever version noble-post-quantum targets
+
+      # 3. Install NPM dependencies
+      - name: Install dependencies
+        run: npm ci
+
+      # 4. Install Chromium and its OS-level dependencies
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium --with-deps
+
+      # 5. Execute the tests
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      # 6. (Optional) Upload the test report if things fail
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules
 *.d.ts.map
 /test/build
 /test/compiled
+/dist
+/playwright-report
+/test-results

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@noble/ciphers": "~2.2.0",
         "@noble/curves": "~2.2.0",
-        "@noble/hashes": "~2.2.0"
+        "@noble/hashes": "~2.2.0",
+        "@playwright/test": "^1.60.0-beta-1779821441000"
       },
       "devDependencies": {
         "@paulmillr/jsbt": "0.6.0",
@@ -59,12 +60,27 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
       "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "license": "MIT",
+      "devDependencies": {
+        "@paulmillr/jsbt": "f:../jsbt",
+        "@types/node": "25.3.0",
+        "fast-check": "4.2.0",
+        "prettier": "3.6.2",
+        "typescript": "6.0.2"
+      },
       "engines": {
         "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@noble/curves": {
+      "resolved": "../noble-curves",
+      "link": true
+    },
+    "node_modules/@noble/hashes": {
+      "resolved": "../noble-hashes",
+      "link": true
     },
     "node_modules/@paulmillr/jsbt": {
       "version": "0.6.0",
@@ -107,6 +123,49 @@
       },
       "engines": {
         "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/npm-3p-trusted/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0-beta-1779821441000",
+      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/npm-3p-trusted/playwright/-/playwright-1.60.0-beta-1779821441000.tgz",
+      "integrity": "sha512-TJ96CR0leOTCuH63rnJmE9sJjsgpDvyxNNghtQB3jlX91LRwE+a567PPgvke4/kQMe6owJKBsWxdSTITvYL1Lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0-beta-1779821441000"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0-beta-1779821441000",
+      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/npm-3p-trusted/playwright-core/-/playwright-core-1.60.0-beta-1779821441000.tgz",
+      "integrity": "sha512-MrYuiAP0MNcRaw0jy7ci0PuCWGLZ0eiErH6xDHXc6ci1zS9lE0tsUrk7YycorM+NB0qXdOOgCjo7gqzWymzBsA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/prettier": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@noble/ciphers": "~2.2.0",
     "@noble/curves": "~2.2.0",
-    "@noble/hashes": "~2.2.0"
+    "@noble/hashes": "~2.2.0",
+    "@playwright/test": "^1.60.0-beta-1779821441000"
   },
   "devDependencies": {
     "@paulmillr/jsbt": "0.6.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+// playwright.config.ts
+import { defineConfig, devices, PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = defineConfig({
+  testDir: './test',
+  projects: [
+    {
+      name: 'chrome-canary-pqc',
+      use: {
+        ...devices['Desktop Chrome'],
+        channel: 'chrome-canary',
+        launchOptions: {
+          args: [
+            '--enable-automation',
+            '--enable-experimental-web-platform-features',
+            '--enable-features=WebCryptoPQC',
+            '--enable-blink-features=WebCryptoPQC',
+          ],
+        },
+      },
+    },
+  ],
+});
+
+export default config;

--- a/test/webcrypto-smoke.test.ts
+++ b/test/webcrypto-smoke.test.ts
@@ -1,0 +1,190 @@
+import { test, expect } from '@playwright/test';
+
+test('debug: print browser version', async ({ browser }) => {
+  console.log(`Running Chromium Engine Version: ${browser.version()}`);
+});
+
+test('WebCrypto ML-KEM-768 is fully enabled and functional', async ({ page }) => {
+  await test.step('0. Navigate to a Secure Context', async () => {
+    // 1. Intercept network requests to a fake localhost address
+    await page.route('http://localhost:9999/', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<html><body>Mocked Secure Context</body></html>',
+      });
+    });
+
+    // 2. Navigate there so Chromium enables window.crypto.subtle
+    await page.goto('http://localhost:9999/');
+  });
+
+  await test.step('1. Ensure SubtleCrypto is available', async () => {
+    const hasSubtle = await page.evaluate(() => {
+      return window.crypto && window.crypto.subtle !== undefined;
+    });
+    expect(hasSubtle, 'window.crypto.subtle should be defined').toBeTruthy();
+  });
+
+  await test.step('2. Generate ML-KEM-768 KeyPair', async () => {
+    const keyGenState = await page.evaluate(async () => {
+      try {
+        // Generate keys and save them to the global window object for subsequent steps
+        const kp = await window.crypto.subtle.generateKey(
+          { name: 'ML-KEM-768' },
+          true,
+          ['encapsulateBits', 'decapsulateBits'] // Draft spec usages for KEMs
+        );
+
+        (window as any).pqcKeyPair = kp;
+
+        return {
+          success: true,
+          pubAlgName: kp.publicKey.algorithm.name,
+          privAlgName: kp.privateKey.algorithm.name,
+        };
+      } catch (error) {
+        return { success: false, error: (error as Error).name };
+      }
+    });
+
+    // If this fails, the PQC flag isn't working or the algorithm name is rejected
+    expect(keyGenState.success, `Key generation failed: ${keyGenState.error}`).toBe(true);
+    expect(keyGenState.pubAlgName).toBe('ML-KEM-768');
+    expect(keyGenState.privAlgName).toBe('ML-KEM-768');
+  });
+
+  await test.step('3. Encapsulate a shared secret against the Public Key', async () => {
+    const encapsState = await page.evaluate(async () => {
+      try {
+        // Cast subtle to any because standard TypeScript DOM types lack KEM methods currently
+        const subtleAny = window.crypto.subtle as any;
+        const kp = (window as any).pqcKeyPair;
+
+        const { sharedKey, ciphertext } = await subtleAny.encapsulateBits(
+          { name: 'ML-KEM-768' },
+          kp.publicKey
+        );
+
+        // Save outputs to window for the decapsulation step
+        (window as any).pqcCiphertext = ciphertext;
+        (window as any).pqcSharedKey = sharedKey;
+
+        return {
+          success: true,
+          sharedKeyByteLength: sharedKey.byteLength,
+          ciphertextByteLength: ciphertext.byteLength,
+        };
+      } catch (error) {
+        return { success: false, error: (error as Error).name };
+      }
+    });
+
+    expect(encapsState.success, `Encapsulation failed: ${encapsState.error}`).toBe(true);
+
+    // ML-KEM shared secrets are always 256-bit (32 bytes)
+    expect(encapsState.sharedKeyByteLength).toBe(32);
+
+    // ML-KEM-768 ciphertext is 1088 bytes according to FIPS 203 draft
+    expect(encapsState.ciphertextByteLength).toBe(1088);
+  });
+
+  await test.step('4. Decapsulate the ciphertext using the Private Key', async () => {
+    const decapsState = await page.evaluate(async () => {
+      try {
+        const subtleAny = window.crypto.subtle as any;
+        const kp = (window as any).pqcKeyPair;
+        const ciphertext = (window as any).pqcCiphertext;
+        const originalSharedKey = (window as any).pqcSharedKey;
+
+        // The receiver uses their private key to unpack the ciphertext
+        const decapsulatedKey = await subtleAny.decapsulateBits(
+          { name: 'ML-KEM-768' },
+          kp.privateKey,
+          ciphertext
+        );
+
+        // Compare the bytes to ensure both parties ended up with the identical secret
+        const originalBytes = new Uint8Array(originalSharedKey);
+        const decapsulatedBytes = new Uint8Array(decapsulatedKey);
+
+        const isMatch =
+          originalBytes.length === decapsulatedBytes.length &&
+          originalBytes.every((val, i) => val === decapsulatedBytes[i]);
+
+        return { success: true, isMatch };
+      } catch (error) {
+        return { success: false, error: (error as Error).name };
+      }
+    });
+
+    expect(decapsState.success, `Decapsulation failed: ${decapsState.error}`).toBe(true);
+    expect(
+      decapsState.isMatch,
+      'The decapsulated key must exactly match the encapsulated key'
+    ).toBe(true);
+  });
+});
+
+test('debug: print active chromium flags via CDP', async ({ browser }) => {
+  // 1. Open a direct DevTools Protocol session with the browser engine
+  const session = await browser.newBrowserCDPSession();
+
+  // 2. Ask Chromium for the exact arguments it was launched with
+  const result = await session.send('Browser.getBrowserCommandLine');
+
+  console.log('Active Command Line Arguments:');
+  console.log(result.arguments); // This prints the array of active flags
+
+  // 3. Verify our experimental flag made it into the launch sequence
+  expect(result.arguments).toContain('--enable-features=WebCryptoPQC');
+});
+
+test('spy on Web Crypto generateKey call', async ({ page }) => {
+  // 1. Array to hold the intercepted calls in our Node environment
+  const cryptoCalls: any[] = [];
+
+  // 2. Expose a function so the browser can send data back to Playwright
+  await page.exposeFunction('reportCryptoCall', (algorithm: any) => {
+    cryptoCalls.push(algorithm);
+  });
+
+  // 3. Inject a script before the page loads to wrap the native API
+  await page.addInitScript(() => {
+    const originalGenerateKey = window.crypto.subtle.generateKey.bind(window.crypto.subtle);
+
+    // @ts-ignore
+    window.crypto.subtle.generateKey = async function (algorithm, extractable, keyUsages) {
+      window.reportCryptoCall(algorithm);
+      return originalGenerateKey(algorithm, extractable, keyUsages);
+    };
+  });
+
+  // 4. FIX: Mock the route so we don't depend on a live server running on port 3000
+  // This satisfies both the Secure Context constraint and the page navigation
+  await page.route('https://pqc-test.local', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: '<html><body><h1>PQC Testing Sandbox</h1></body></html>',
+    });
+  });
+
+  // Navigate to our secure, mocked domain
+  await page.goto('https://pqc-test.local');
+
+  // 5. Trigger the code right inside the browser context
+  await page.evaluate(async () => {
+    // This executes inside the browser, triggering our spy!
+    await window.crypto.subtle.generateKey(
+      { name: 'ML-KEM-768' },
+      true,
+      // FIX: Use the KEM-specific usages mandated by the WebCrypto spec
+      ['encapsulateBits', 'decapsulateBits']
+    );
+  });
+
+  // 6. Assert! Verify your spy caught the execution
+  expect(cryptoCalls.length).toBeGreaterThan(0);
+  expect(cryptoCalls[0].name).toBe('ML-KEM-768');
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,6 @@
     "rootDir": "src",
     "outDir": "."
   },
-  "include": [
-    "src"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Part of #43 

What is the purpose of this change?
- Demonstrate the use of Playwright with Chrome Canary to use the flag controlled WebCrypto PQC feature, ahead of actual use.

Why doesn't this change affect any part of the larger noble-post-quantum project?
- This is specific commit is limited to the smoke test. It will be followed by a stacked commit(s) that opportunistically uses the Chrome WebCrypto PQC APIs and tests that appropriately.