### PR TITLE
Use PQC WebCrypto in webcrypto.ts and a joint fallback API, webcrypto_with_fallback.ts

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,41 @@
+name: Playwright PQC Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. Grab your repository's code
+      - uses: actions/checkout@v4
+
+      # 2. Set up the Node environment
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20 # Or whatever version noble-post-quantum targets
+
+      # 3. Install NPM dependencies
+      - name: Install dependencies
+        run: npm ci
+
+      # 4. Install Chromium and its OS-level dependencies
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium --with-deps
+
+      # 5. Execute the tests
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      # 6. (Optional) Upload the test report if things fail
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules
 *.d.ts.map
 /test/build
 /test/compiled
+/dist
+/playwright-report
+/test-results

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@noble/ciphers": "~2.2.0",
         "@noble/curves": "~2.2.0",
-        "@noble/hashes": "~2.2.0"
+        "@noble/hashes": "~2.2.0",
+        "@playwright/test": "^1.60.0-beta-1779821441000"
       },
       "devDependencies": {
         "@paulmillr/jsbt": "0.6.0",
@@ -59,12 +60,27 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
       "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "license": "MIT",
+      "devDependencies": {
+        "@paulmillr/jsbt": "f:../jsbt",
+        "@types/node": "25.3.0",
+        "fast-check": "4.2.0",
+        "prettier": "3.6.2",
+        "typescript": "6.0.2"
+      },
       "engines": {
         "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@noble/curves": {
+      "resolved": "../noble-curves",
+      "link": true
+    },
+    "node_modules/@noble/hashes": {
+      "resolved": "../noble-hashes",
+      "link": true
     },
     "node_modules/@paulmillr/jsbt": {
       "version": "0.6.0",
@@ -107,6 +123,49 @@
       },
       "engines": {
         "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/npm-3p-trusted/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0-beta-1779821441000",
+      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/npm-3p-trusted/playwright/-/playwright-1.60.0-beta-1779821441000.tgz",
+      "integrity": "sha512-TJ96CR0leOTCuH63rnJmE9sJjsgpDvyxNNghtQB3jlX91LRwE+a567PPgvke4/kQMe6owJKBsWxdSTITvYL1Lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0-beta-1779821441000"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0-beta-1779821441000",
+      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/npm-3p-trusted/playwright-core/-/playwright-core-1.60.0-beta-1779821441000.tgz",
+      "integrity": "sha512-MrYuiAP0MNcRaw0jy7ci0PuCWGLZ0eiErH6xDHXc6ci1zS9lE0tsUrk7YycorM+NB0qXdOOgCjo7gqzWymzBsA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/prettier": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@noble/ciphers": "~2.2.0",
     "@noble/curves": "~2.2.0",
-    "@noble/hashes": "~2.2.0"
+    "@noble/hashes": "~2.2.0",
+    "@playwright/test": "^1.60.0-beta-1779821441000"
   },
   "devDependencies": {
     "@paulmillr/jsbt": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "./ml-dsa.js": "./ml-dsa.js",
     "./ml-kem.js": "./ml-kem.js",
     "./slh-dsa.js": "./slh-dsa.js",
-    "./utils.js": "./utils.js"
+    "./utils.js": "./utils.js",
+    "./webcrypto.js": "./webcrypto.js",
+    "./webcrypto_with_fallback.js": "./webcrypto_with_fallback.js"
   },
   "engines": {
     "node": ">= 20.19.0"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,8 @@ const config: PlaywrightTestConfig = defineConfig({
       name: 'chrome-canary-pqc',
       use: {
         ...devices['Desktop Chrome'],
+        // Currently using Chrome Canary because X-Wing is only available on
+        // v151+, which is not yet available in the playwright stable channel.
         channel: 'chrome-canary',
         launchOptions: {
           args: [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+// playwright.config.ts
+import { defineConfig, devices, PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = defineConfig({
+  testDir: './test',
+  projects: [
+    {
+      name: 'chrome-canary-pqc',
+      use: {
+        ...devices['Desktop Chrome'],
+        channel: 'chrome-canary',
+        launchOptions: {
+          args: [
+            '--enable-automation',
+            '--enable-experimental-web-platform-features',
+            '--enable-features=WebCryptoPQC',
+            '--enable-blink-features=WebCryptoPQC',
+          ],
+        },
+      },
+    },
+  ],
+});
+
+export default config;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -712,3 +712,71 @@ export function astring(value: unknown, title: string = ''): string {
   }
   return value;
 }
+
+/**
+ * Reads a DER length from the current offset.
+ * Returns [length, newOffset].
+ */
+function readDERLength(buf: Uint8Array, offset: number): [number, number] {
+  const first = buf[offset++];
+  if (first < 0x80) return [first, offset];
+  const lengthOfLength = first & 0x7f;
+  if (lengthOfLength === 0 || lengthOfLength > 4) throw new Error('Unsupported ASN.1 length');
+  let length = 0;
+  for (let i = 0; i < lengthOfLength; i++) {
+    length = (length << 8) | buf[offset++];
+  }
+  return [length, offset];
+}
+
+/**
+ * Dynamically unwraps an SPKI structure to extract the raw public key.
+ */
+export function unwrapSPKI(spki: Uint8Array): Uint8Array {
+  let offset = 0;
+  if (spki[offset++] !== 0x30) throw new Error('Expected SPKI SEQUENCE');
+  [, offset] = readDERLength(spki, offset);
+
+  if (spki[offset++] !== 0x30) throw new Error('Expected AlgorithmIdentifier SEQUENCE');
+  let algLen;
+  [algLen, offset] = readDERLength(spki, offset);
+  offset += algLen; // skip AlgorithmIdentifier
+
+  if (spki[offset++] !== 0x03) throw new Error('Expected SubjectPublicKey BIT STRING');
+  let bitStringLen;
+  [bitStringLen, offset] = readDERLength(spki, offset);
+  
+  if (spki[offset++] !== 0x00) throw new Error('Expected byte-aligned BIT STRING');
+  return spki.subarray(offset, offset + bitStringLen - 1);
+}
+
+/**
+ * Encodes a length into ASN.1 DER format.
+ */
+function encodeDERLength(len: number): Uint8Array {
+  if (len < 128) {
+    return new Uint8Array([len]);
+  }
+  const bytes = [];
+  let temp = len;
+  while (temp > 0) {
+    bytes.unshift(temp & 0xff);
+    temp >>>= 8;
+  }
+  return new Uint8Array([0x80 | bytes.length, ...bytes]);
+}
+
+/**
+ * Dynamically wraps a raw public key into an SPKI structure.
+ */
+export function wrapSPKI(oid: Uint8Array, rawKey: Uint8Array): Uint8Array {
+  const algIdSeqLength = encodeDERLength(oid.length);
+  const algIdSeq = new Uint8Array([0x30, ...algIdSeqLength, ...oid]);
+
+  const bitStringLength = encodeDERLength(rawKey.length + 1);
+  const bitString = new Uint8Array([0x03, ...bitStringLength, 0x00, ...rawKey]);
+
+  const spkiLength = encodeDERLength(algIdSeq.length + bitString.length);
+  return new Uint8Array([0x30, ...spkiLength, ...algIdSeq, ...bitString]);
+}
+

--- a/src/webcrypto.ts
+++ b/src/webcrypto.ts
@@ -1,0 +1,606 @@
+import { type TArg, type TRet, type SigOpts, type VerOpts, unwrapSPKI, wrapSPKI } from './utils.ts';
+
+export type PQCKeyUsage = KeyUsage | 'encapsulateBits' | 'decapsulateBits';
+
+export type PQCSubtleCrypto = Omit<
+  SubtleCrypto,
+  'generateKey' | 'importKey' | 'sign' | 'verify'
+> & {
+  generateKey(
+    algorithm: AlgorithmIdentifier | { name: string },
+    extractable: boolean,
+    keyUsages: readonly PQCKeyUsage[]
+  ): Promise<CryptoKeyPair>;
+  importKey(
+    format: 'jwk',
+    keyData: JsonWebKey,
+    algorithm: AlgorithmIdentifier | { name: string },
+    extractable: boolean,
+    keyUsages: readonly PQCKeyUsage[]
+  ): Promise<CryptoKey>;
+  importKey(
+    format: Exclude<KeyFormat, 'jwk'> | 'raw-seed',
+    keyData: BufferSource | Uint8Array,
+    algorithm: AlgorithmIdentifier | { name: string },
+    extractable: boolean,
+    keyUsages: readonly PQCKeyUsage[]
+  ): Promise<CryptoKey>;
+  getPublicKey(key: CryptoKey, keyUsages: readonly PQCKeyUsage[]): Promise<CryptoKey>;
+  encapsulateBits(
+    algorithm: AlgorithmIdentifier | { name: string },
+    key: CryptoKey
+  ): Promise<{ sharedKey: ArrayBuffer; ciphertext: ArrayBuffer }>;
+  decapsulateBits(
+    algorithm: AlgorithmIdentifier | { name: string },
+    key: CryptoKey,
+    ciphertext: BufferSource | Uint8Array
+  ): Promise<ArrayBuffer>;
+  sign(
+    algorithm: AlgorithmIdentifier | { name: string },
+    key: CryptoKey,
+    data: BufferSource | Uint8Array
+  ): Promise<ArrayBuffer>;
+  verify(
+    algorithm: AlgorithmIdentifier | { name: string },
+    key: CryptoKey,
+    signature: BufferSource | Uint8Array,
+    data: BufferSource | Uint8Array
+  ): Promise<boolean>;
+};
+
+export type AsyncKEM = {
+  info?: { type?: string };
+  lengths: {
+    seed?: number;
+    publicKey?: number;
+    secretKey?: number;
+    cipherText?: number;
+    msg?: number;
+    msgRand?: number;
+  };
+  keygen: (
+    seed?: TArg<Uint8Array>,
+    opts?: TArg<{ extractable?: boolean }>
+  ) => Promise<{ secretKey: TRet<Uint8Array | CryptoKey>; publicKey: TRet<Uint8Array> }>;
+  getPublicKey: (secretKey: TArg<Uint8Array | CryptoKey>) => Promise<TRet<Uint8Array>>;
+  encapsulate: (
+    publicKey: TArg<Uint8Array>,
+    msg?: TArg<Uint8Array>
+  ) => Promise<{ cipherText: TRet<Uint8Array>; sharedSecret: TRet<Uint8Array> }>;
+  decapsulate: (
+    cipherText: TArg<Uint8Array>,
+    secretKey: TArg<Uint8Array | CryptoKey>
+  ) => Promise<TRet<Uint8Array>>;
+};
+
+export type AsyncDSA = {
+  info?: { type?: string };
+  securityLevel: number;
+  lengths: {
+    seed?: number;
+    publicKey?: number;
+    secretKey?: number;
+    signRand?: number;
+    signature?: number;
+  };
+  keygen: (
+    seed?: TArg<Uint8Array>,
+    opts?: TArg<{ extractable?: boolean }>
+  ) => Promise<{ secretKey: TRet<Uint8Array | CryptoKey>; publicKey: TRet<Uint8Array> }>;
+  getPublicKey: (secretKey: TArg<Uint8Array | CryptoKey>) => Promise<TRet<Uint8Array>>;
+  sign: (
+    msg: TArg<Uint8Array>,
+    secretKey: TArg<Uint8Array | CryptoKey>,
+    opts?: TArg<SigOpts>
+  ) => Promise<TRet<Uint8Array>>;
+  verify: (
+    sig: TArg<Uint8Array>,
+    msg: TArg<Uint8Array>,
+    publicKey: TArg<Uint8Array>,
+    opts?: TArg<VerOpts>
+  ) => Promise<boolean>;
+  prehash: () => void;
+  internal?: any;
+};
+
+export function base64url(bytes: Uint8Array): string {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function debase64url(str: string): Uint8Array {
+  let s = str;
+  const pad = s.length % 4;
+  if (pad === 2) s += '==';
+  else if (pad === 3) s += '=';
+  const bin = atob(s.replace(/-/g, '+').replace(/_/g, '/'));
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+export const ML_KEM_OIDS: Record<number, Uint8Array> = {
+  // ML-KEM-512 OID: 2.16.840.1.101.3.4.4.1
+  2: new Uint8Array([0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x01]),
+  // ML-KEM-768 OID: 2.16.840.1.101.3.4.4.2
+  3: new Uint8Array([0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x02]),
+  // ML-KEM-1024 OID: 2.16.840.1.101.3.4.4.3
+  4: new Uint8Array([0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x03]),
+};
+
+export const ML_DSA_OIDS: Record<number, Uint8Array> = {
+  // ML-DSA-44 OID: 2.16.840.1.101.3.4.3.17
+  4: new Uint8Array([0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x11]),
+  // ML-DSA-65 OID: 2.16.840.1.101.3.4.3.18
+  6: new Uint8Array([0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x12]),
+  // ML-DSA-87 OID: 2.16.840.1.101.3.4.3.19
+  8: new Uint8Array([0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x13]),
+};
+
+const isWebCryptoSupported =
+  typeof globalThis !== 'undefined' && globalThis.crypto && globalThis.crypto.subtle !== undefined;
+
+function getSubtle(): PQCSubtleCrypto {
+  return globalThis.crypto.subtle as unknown as PQCSubtleCrypto;
+}
+
+function assertSupported() {
+  if (!isWebCryptoSupported) {
+    throw new DOMException('WebCrypto is not supported in this environment', 'NotSupportedError');
+  }
+}
+
+/**
+ * Wraps WebCrypto ML-KEM APIs into a unified interface matching the pure TypeScript implementation.
+ *
+ * This implementation uses a custom PQCSubtleCrypto interface to ensure strong typing.
+ */
+function wrapMLKEM(K: number, algName: string, lengths: AsyncKEM['lengths']): TRet<AsyncKEM> {
+  const impl: AsyncKEM = {
+    info: Object.freeze({ type: 'ml-kem' }),
+    lengths,
+    async keygen(seed?: TArg<Uint8Array>, opts?: TArg<{ extractable?: boolean }>) {
+      assertSupported();
+      if (seed !== undefined) {
+        throw new Error('Deterministic keygen with seed is not supported in pure WebCrypto');
+      }
+      const algorithm = { name: algName };
+      const extractable = opts?.extractable ?? false;
+      const keyUsages: readonly PQCKeyUsage[] = ['encapsulateBits', 'decapsulateBits'];
+      const keyPair = await getSubtle().generateKey(algorithm, extractable, keyUsages);
+
+      const formatSpki = 'spki';
+      const publicKeyBuffer = await getSubtle().exportKey(formatSpki, keyPair.publicKey);
+
+      let secretKey: TRet<Uint8Array | CryptoKey> =
+        keyPair.privateKey as unknown as TRet<CryptoKey>;
+      if (extractable) {
+        const formatPkcs8 = 'pkcs8';
+        const secretKeyBuffer = await getSubtle().exportKey(formatPkcs8, keyPair.privateKey);
+        secretKey = new Uint8Array(secretKeyBuffer as ArrayBuffer) as TRet<Uint8Array>;
+      }
+
+      return {
+        publicKey: unwrapSPKI(new Uint8Array(publicKeyBuffer as ArrayBuffer)) as TRet<Uint8Array>,
+        secretKey,
+      };
+    },
+    async getPublicKey(secretKey: TArg<Uint8Array | CryptoKey>) {
+      assertSupported();
+      let privateKey: CryptoKey;
+      if (secretKey instanceof Uint8Array) {
+        const format = 'pkcs8';
+        const keyData = secretKey;
+        const algorithm = { name: algName };
+        const extractable = false;
+        const keyUsages: readonly PQCKeyUsage[] = ['decapsulateBits'];
+        privateKey = await getSubtle().importKey(
+          format,
+          keyData,
+          algorithm,
+          extractable,
+          keyUsages
+        );
+      } else {
+        privateKey = secretKey as CryptoKey;
+      }
+      const publicKey = await getSubtle().getPublicKey(privateKey, ['encapsulateBits']);
+
+      const formatSpki = 'spki';
+      const publicKeyBuffer = await getSubtle().exportKey(formatSpki, publicKey);
+      return unwrapSPKI(new Uint8Array(publicKeyBuffer as ArrayBuffer)) as TRet<Uint8Array>;
+    },
+    async encapsulate(publicKey: TArg<Uint8Array>, msg?: TArg<Uint8Array>) {
+      assertSupported();
+      if (msg !== undefined) {
+        throw new Error(
+          'Encapsulate with custom message/entropy is not supported in pure WebCrypto'
+        );
+      }
+      const oid = ML_KEM_OIDS[K];
+      if (!oid) throw new Error('Unsupported K size');
+      const spki = wrapSPKI(oid, publicKey as Uint8Array);
+      const format = 'spki';
+      const keyData = spki as Uint8Array;
+      const algorithm = { name: algName };
+      const extractable = true;
+      const keyUsages: readonly PQCKeyUsage[] = ['encapsulateBits'];
+      const pubKey = await getSubtle().importKey(
+        format,
+        keyData,
+        algorithm,
+        extractable,
+        keyUsages
+      );
+      const { sharedKey, ciphertext } = await getSubtle().encapsulateBits(
+        { name: algName },
+        pubKey
+      );
+      return {
+        cipherText: new Uint8Array(ciphertext as ArrayBuffer) as TRet<Uint8Array>,
+        sharedSecret: new Uint8Array(sharedKey as ArrayBuffer) as TRet<Uint8Array>,
+      };
+    },
+    async decapsulate(cipherText: TArg<Uint8Array>, secretKey: TArg<Uint8Array | CryptoKey>) {
+      assertSupported();
+      let privKey: CryptoKey;
+      if (secretKey instanceof Uint8Array) {
+        const format = 'pkcs8';
+        const keyData = secretKey;
+        const algorithm = { name: algName };
+        const extractable = false;
+        const keyUsages: readonly PQCKeyUsage[] = ['decapsulateBits'];
+        privKey = await getSubtle().importKey(format, keyData, algorithm, extractable, keyUsages);
+      } else {
+        privKey = secretKey as CryptoKey;
+      }
+      const sharedSecret = await getSubtle().decapsulateBits(
+        { name: algName },
+        privKey,
+        cipherText as Uint8Array
+      );
+      return new Uint8Array(sharedSecret as ArrayBuffer) as TRet<Uint8Array>;
+    },
+  };
+  return Object.freeze(impl) as unknown as TRet<AsyncKEM>;
+}
+
+/**
+ * Wraps WebCrypto ML-DSA APIs into a unified interface matching the pure TypeScript implementation.
+ *
+ * This implementation uses a custom PQCSubtleCrypto interface to ensure strong typing.
+ */
+function wrapDSA(
+  K: number,
+  algName: string,
+  lengths: AsyncDSA['lengths'],
+  securityLevel: number
+): TRet<AsyncDSA> {
+  const impl: AsyncDSA = {
+    info: Object.freeze({ type: 'ml-dsa' }),
+    securityLevel,
+    lengths,
+    async keygen(seed?: TArg<Uint8Array>, opts?: TArg<{ extractable?: boolean }>) {
+      assertSupported();
+      if (seed !== undefined) {
+        throw new Error('Deterministic keygen with seed is not supported in pure WebCrypto');
+      }
+      const algorithm = { name: algName };
+      const extractable = opts?.extractable ?? false;
+      const keyUsages: readonly PQCKeyUsage[] = ['sign', 'verify'];
+      const keyPair = await getSubtle().generateKey(algorithm, extractable, keyUsages);
+
+      const formatSpki = 'spki';
+      const publicKeyBuffer = await getSubtle().exportKey(formatSpki, keyPair.publicKey);
+
+      let secretKey: TRet<Uint8Array | CryptoKey> =
+        keyPair.privateKey as unknown as TRet<CryptoKey>;
+      if (extractable) {
+        const formatPkcs8 = 'pkcs8';
+        const secretKeyBuffer = await getSubtle().exportKey(formatPkcs8, keyPair.privateKey);
+        secretKey = new Uint8Array(secretKeyBuffer as ArrayBuffer) as TRet<Uint8Array>;
+      }
+
+      return {
+        publicKey: unwrapSPKI(new Uint8Array(publicKeyBuffer as ArrayBuffer)) as TRet<Uint8Array>,
+        secretKey,
+      };
+    },
+    async getPublicKey(secretKey: TArg<Uint8Array | CryptoKey>) {
+      assertSupported();
+      let privateKey: CryptoKey;
+      if (secretKey instanceof Uint8Array) {
+        const format = 'pkcs8';
+        const keyData = secretKey;
+        const algorithm = { name: algName };
+        const extractable = false;
+        const keyUsages: readonly PQCKeyUsage[] = ['sign'];
+        privateKey = await getSubtle().importKey(
+          format,
+          keyData,
+          algorithm,
+          extractable,
+          keyUsages
+        );
+      } else {
+        privateKey = secretKey as CryptoKey;
+      }
+      const publicKey = await getSubtle().getPublicKey(privateKey, ['verify']);
+
+      const formatSpki = 'spki';
+      const publicKeyBuffer = await getSubtle().exportKey(formatSpki, publicKey);
+      return unwrapSPKI(new Uint8Array(publicKeyBuffer as ArrayBuffer)) as TRet<Uint8Array>;
+    },
+    async sign(
+      msg: TArg<Uint8Array>,
+      secretKey: TArg<Uint8Array | CryptoKey>,
+      opts: TArg<SigOpts> = {}
+    ) {
+      assertSupported();
+      let privKey: CryptoKey;
+      if (secretKey instanceof Uint8Array) {
+        const format = 'pkcs8';
+        const keyData = secretKey;
+        const algorithm = { name: algName };
+        const extractable = false;
+        const keyUsages: readonly PQCKeyUsage[] = ['sign'];
+        privKey = await getSubtle().importKey(format, keyData, algorithm, extractable, keyUsages);
+      } else {
+        privKey = secretKey as CryptoKey;
+      }
+      const algParams: any = { name: algName };
+      if (opts.context !== undefined) {
+        algParams.context = opts.context;
+      }
+      const signature = await getSubtle().sign(algParams, privKey, msg as Uint8Array);
+      return new Uint8Array(signature as ArrayBuffer) as TRet<Uint8Array>;
+    },
+    async verify(
+      sig: TArg<Uint8Array>,
+      msg: TArg<Uint8Array>,
+      publicKey: TArg<Uint8Array>,
+      opts: TArg<VerOpts> = {}
+    ) {
+      assertSupported();
+      const oid = ML_DSA_OIDS[K];
+      if (!oid) throw new Error('Unsupported K size');
+      const wrappedKey = wrapSPKI(oid, publicKey as Uint8Array);
+      const format = 'spki';
+      const keyData = wrappedKey as Uint8Array;
+      const algorithm = { name: algName };
+      const extractable = false;
+      const keyUsages: readonly PQCKeyUsage[] = ['verify'];
+      const importedKey = await getSubtle().importKey(
+        format,
+        keyData,
+        algorithm,
+        extractable,
+        keyUsages
+      );
+      const algParams: any = { name: algName };
+      if (opts.context !== undefined) {
+        algParams.context = opts.context;
+      }
+      return await getSubtle().verify(algParams, importedKey, sig as Uint8Array, msg as Uint8Array);
+    },
+    prehash() {
+      throw new Error('Prehash is not supported in pure WebCrypto submodule');
+    },
+  };
+  return Object.freeze(impl) as unknown as TRet<AsyncDSA>;
+}
+
+export const ml_kem512: TRet<AsyncKEM> = /* @__PURE__ */ wrapMLKEM(2, 'ML-KEM-512', {
+  seed: 64,
+  msg: 32,
+  msgRand: 32,
+  secretKey: 86,
+  publicKey: 800,
+  cipherText: 768,
+});
+export const ml_kem768: TRet<AsyncKEM> = /* @__PURE__ */ wrapMLKEM(3, 'ML-KEM-768', {
+  seed: 64,
+  msg: 32,
+  msgRand: 32,
+  secretKey: 86,
+  publicKey: 1184,
+  cipherText: 1088,
+});
+export const ml_kem1024: TRet<AsyncKEM> = /* @__PURE__ */ wrapMLKEM(4, 'ML-KEM-1024', {
+  seed: 64,
+  msg: 32,
+  msgRand: 32,
+  secretKey: 86,
+  publicKey: 1568,
+  cipherText: 1568,
+});
+
+export const ml_dsa44: TRet<AsyncDSA> = /* @__PURE__ */ wrapDSA(
+  4,
+  'ML-DSA-44',
+  { seed: 32, secretKey: 54, publicKey: 1312, signature: 2420 },
+  128
+);
+export const ml_dsa65: TRet<AsyncDSA> = /* @__PURE__ */ wrapDSA(
+  6,
+  'ML-DSA-65',
+  { seed: 32, secretKey: 54, publicKey: 1952, signature: 3300 },
+  192
+);
+export const ml_dsa87: TRet<AsyncDSA> = /* @__PURE__ */ wrapDSA(
+  8,
+  'ML-DSA-87',
+  { seed: 32, secretKey: 54, publicKey: 2592, signature: 4627 },
+  256
+);
+
+const XWING_ALG_NAME = 'MLKEM768-X25519';
+
+/**
+ * Native WebCrypto implementation of X-Wing (MLKEM768-X25519).
+ */
+const xWingImpl: AsyncKEM = {
+  info: Object.freeze({ type: 'ml-kem-x25519' }),
+  lengths: {
+    seed: 32,
+    publicKey: 1216,
+    secretKey: 1248,
+    cipherText: 1120,
+  },
+  async keygen(seed?: TArg<Uint8Array>, opts?: TArg<{ extractable?: boolean }>) {
+    assertSupported();
+    if (seed !== undefined) {
+      throw new Error('Deterministic keygen with seed is not supported in pure WebCrypto');
+    }
+    const algorithm = { name: XWING_ALG_NAME };
+    const extractable = opts?.extractable ?? false;
+    const keyUsages: readonly PQCKeyUsage[] = ['encapsulateBits', 'decapsulateBits'];
+    const kp = await getSubtle().generateKey(algorithm, extractable, keyUsages);
+
+    const formatJwk = 'jwk';
+    const jwkPub = await getSubtle().exportKey(formatJwk, kp.publicKey);
+    const pubBytes = debase64url((jwkPub as any).pub!);
+
+    let secretKey: TRet<Uint8Array | CryptoKey> = kp.privateKey as unknown as TRet<CryptoKey>;
+    if (extractable) {
+      const jwkPriv = await getSubtle().exportKey(formatJwk, kp.privateKey);
+      const privBytes = debase64url((jwkPriv as any).priv!);
+      const secretKeyBytes = new Uint8Array(privBytes.length + pubBytes.length);
+      secretKeyBytes.set(privBytes, 0);
+      secretKeyBytes.set(pubBytes, privBytes.length);
+      secretKey = secretKeyBytes as TRet<Uint8Array>;
+    }
+
+    return {
+      publicKey: pubBytes as TRet<Uint8Array>,
+      secretKey,
+    };
+  },
+  async getPublicKey(secretKey: TArg<Uint8Array | CryptoKey>) {
+    assertSupported();
+    if (!(secretKey instanceof Uint8Array)) {
+      const pubKey = await getSubtle().getPublicKey(secretKey as CryptoKey, ['encapsulateBits']);
+      const formatJwk = 'jwk';
+      const jwkPub = await getSubtle().exportKey(formatJwk, pubKey);
+      return debase64url((jwkPub as any).pub!) as TRet<Uint8Array>;
+    }
+    const skBytes = secretKey;
+    if (skBytes.length === 1248) {
+      return skBytes.subarray(32) as TRet<Uint8Array>;
+    }
+    if (skBytes.length === 32) {
+      const format = 'raw-seed';
+      const algorithm = { name: XWING_ALG_NAME };
+      const extractable = false;
+      const keyUsages: readonly PQCKeyUsage[] = ['decapsulateBits'];
+      const privKey = await getSubtle().importKey(
+        format as Exclude<KeyFormat, 'jwk'> | 'raw-seed',
+        skBytes,
+        algorithm,
+        extractable,
+        keyUsages
+      );
+      const pubKey = await getSubtle().getPublicKey(privKey, ['encapsulateBits']);
+      const formatJwk = 'jwk';
+      const jwkPub = await getSubtle().exportKey(formatJwk, pubKey);
+      return debase64url((jwkPub as any).pub!) as TRet<Uint8Array>;
+    }
+    throw new Error('Invalid secret key length');
+  },
+  async encapsulate(publicKey: TArg<Uint8Array>, msg?: TArg<Uint8Array>) {
+    assertSupported();
+    if (msg !== undefined) {
+      throw new Error('Encapsulate with custom message/entropy is not supported in pure WebCrypto');
+    }
+    const formatJwk = 'jwk';
+    const keyData = {
+      kty: 'AKP',
+      alg: XWING_ALG_NAME,
+      key_ops: ['encapsulateBits'],
+      ext: true,
+      pub: base64url(publicKey as Uint8Array),
+    };
+    const algorithm = { name: XWING_ALG_NAME };
+    const extractable = true;
+    const keyUsages: readonly PQCKeyUsage[] = ['encapsulateBits'];
+    const pubKey = await getSubtle().importKey(
+      formatJwk,
+      keyData,
+      algorithm,
+      extractable,
+      keyUsages
+    );
+    const { sharedKey, ciphertext } = await getSubtle().encapsulateBits(
+      { name: XWING_ALG_NAME },
+      pubKey
+    );
+    return {
+      cipherText: new Uint8Array(ciphertext as ArrayBuffer) as TRet<Uint8Array>,
+      sharedSecret: new Uint8Array(sharedKey as ArrayBuffer) as TRet<Uint8Array>,
+    };
+  },
+  async decapsulate(cipherText: TArg<Uint8Array>, secretKey: TArg<Uint8Array | CryptoKey>) {
+    assertSupported();
+    let privKey: CryptoKey;
+    if (!(secretKey instanceof Uint8Array)) {
+      privKey = secretKey as CryptoKey;
+    } else {
+      const skBytes = secretKey;
+      if (skBytes.length === 1248) {
+        const privPart = skBytes.subarray(0, 32);
+        const pubPart = skBytes.subarray(32);
+        const formatJwk = 'jwk';
+        const keyData = {
+          kty: 'AKP',
+          alg: XWING_ALG_NAME,
+          key_ops: ['decapsulateBits'],
+          ext: true,
+          priv: base64url(privPart),
+          pub: base64url(pubPart),
+        };
+        const algorithm = { name: XWING_ALG_NAME };
+        const extractable = false;
+        const keyUsages: readonly PQCKeyUsage[] = ['decapsulateBits'];
+        privKey = await getSubtle().importKey(
+          formatJwk,
+          keyData,
+          algorithm,
+          extractable,
+          keyUsages
+        );
+      } else if (skBytes.length === 32) {
+        const format = 'raw-seed';
+        const algorithm = { name: XWING_ALG_NAME };
+        const extractable = false;
+        const keyUsages: readonly PQCKeyUsage[] = ['decapsulateBits'];
+        privKey = await getSubtle().importKey(
+          format as Exclude<KeyFormat, 'jwk'> | 'raw-seed',
+          skBytes,
+          algorithm,
+          extractable,
+          keyUsages
+        );
+      } else {
+        throw new Error('Invalid secret key length');
+      }
+    }
+
+    try {
+      const sharedSecret = await getSubtle().decapsulateBits(
+        { name: XWING_ALG_NAME },
+        privKey,
+        cipherText as Uint8Array
+      );
+      return new Uint8Array(sharedSecret as ArrayBuffer) as TRet<Uint8Array>;
+    } catch (e) {
+      throw new Error('Native decapsulate failed: ' + (e as Error).message);
+    }
+  },
+};
+export const ml_kem768_x25519: TRet<AsyncKEM> = Object.freeze(
+  xWingImpl
+) as unknown as TRet<AsyncKEM>;
+
+export const XWing: TRet<AsyncKEM> = ml_kem768_x25519;
+export const MLKEM768X25519: TRet<AsyncKEM> = ml_kem768_x25519;

--- a/src/webcrypto_with_fallback.ts
+++ b/src/webcrypto_with_fallback.ts
@@ -1,0 +1,326 @@
+import {
+  ml_kem512 as ts_ml_kem512,
+  ml_kem768 as ts_ml_kem768,
+  ml_kem1024 as ts_ml_kem1024,
+} from './ml-kem.ts';
+import {
+  ml_dsa44 as ts_ml_dsa44,
+  ml_dsa65 as ts_ml_dsa65,
+  ml_dsa87 as ts_ml_dsa87,
+} from './ml-dsa.ts';
+import { ml_kem768_x25519 as ts_ml_kem768_x25519 } from './hybrid.ts';
+
+import {
+  ml_kem512 as wc_ml_kem512,
+  ml_kem768 as wc_ml_kem768,
+  ml_kem1024 as wc_ml_kem1024,
+  ml_dsa44 as wc_ml_dsa44,
+  ml_dsa65 as wc_ml_dsa65,
+  ml_dsa87 as wc_ml_dsa87,
+  ml_kem768_x25519 as wc_ml_kem768_x25519,
+  type AsyncKEM,
+  type AsyncDSA,
+} from './webcrypto.ts';
+
+import { type KEM, type TArg, type TRet, type SigOpts, type VerOpts } from './utils.ts';
+import { type DSA } from './ml-dsa.ts';
+
+// Chrome Canary's WebCrypto PQC implementations currently export compressed seeds wrapped in PKCS8.
+// We use these exact lengths to route operations (like decapsulate/sign) to the WebCrypto backend
+// when it's natively supported and the user passes a WebCrypto-generated key.
+// Note: If standard implementations change their PKCS8 export format to use fully expanded keys,
+// these constants will need to be updated.
+const WEBCRYPTO_MLKEM_PKCS8_LENGTH = 86;
+const WEBCRYPTO_MLDSA_PKCS8_LENGTH = 54;
+
+let isMLKEM512Supported = false;
+let isMLKEM768Supported = false;
+let isMLKEM1024Supported = false;
+
+let isMLDSA44Supported = false;
+let isMLDSA65Supported = false;
+let isMLDSA87Supported = false;
+
+let isXWingSupported = false;
+
+// Probe for WebCrypto support of ML-KEM, ML-DSA, and XWing algorithms.
+if (typeof globalThis !== 'undefined' && globalThis.crypto && globalThis.crypto.subtle) {
+  const subtle = globalThis.crypto.subtle;
+
+  // Probe ML-KEM (subtle is cast to 'any' because standard TS types lack encapsulateBits)
+  if ((subtle as any).encapsulateBits !== undefined) {
+    const mlKem512Alg = { name: 'ML-KEM-512' } as any;
+    const mlKem768Alg = { name: 'ML-KEM-768' } as any;
+    const mlKem1024Alg = { name: 'ML-KEM-1024' } as any;
+    const extractable = true;
+    const keyUsages = ['encapsulateBits', 'decapsulateBits'] as any;
+
+    subtle.generateKey(mlKem512Alg, extractable, keyUsages).then(
+      () => {
+        isMLKEM512Supported = true;
+      },
+      () => {}
+    );
+    subtle.generateKey(mlKem768Alg, extractable, keyUsages).then(
+      () => {
+        isMLKEM768Supported = true;
+      },
+      () => {}
+    );
+    subtle.generateKey(mlKem1024Alg, extractable, keyUsages).then(
+      () => {
+        isMLKEM1024Supported = true;
+      },
+      () => {}
+    );
+  }
+
+  // Probe ML-DSA
+  if (subtle.sign !== undefined) {
+    const mlDsa44Alg = { name: 'ML-DSA-44' } as any;
+    const mlDsa65Alg = { name: 'ML-DSA-65' } as any;
+    const mlDsa87Alg = { name: 'ML-DSA-87' } as any;
+    const extractable = true;
+    const keyUsages = ['sign', 'verify'] as any;
+
+    subtle.generateKey(mlDsa44Alg, extractable, keyUsages).then(
+      () => {
+        isMLDSA44Supported = true;
+      },
+      () => {}
+    );
+    subtle.generateKey(mlDsa65Alg, extractable, keyUsages).then(
+      () => {
+        isMLDSA65Supported = true;
+      },
+      () => {}
+    );
+    subtle.generateKey(mlDsa87Alg, extractable, keyUsages).then(
+      () => {
+        isMLDSA87Supported = true;
+      },
+      () => {}
+    );
+  }
+
+  // Probe XWing
+  if ((subtle as any).encapsulateBits !== undefined) {
+    const xWingAlg = { name: 'MLKEM768-X25519' } as any;
+    const extractable = true;
+    const keyUsages = ['encapsulateBits', 'decapsulateBits'] as any;
+
+    subtle.generateKey(xWingAlg, extractable, keyUsages).then(
+      () => {
+        isXWingSupported = true;
+      },
+      () => {}
+    );
+  }
+}
+
+/**
+ * Creates a KEM instance that opportunistically uses the WebCrypto backend if supported,
+ * but falls back to the pure TypeScript backend if native execution throws or is unsupported.
+ *
+ * Note on Asynchrony:
+ * Although the return type is typed as `TRet` (which allows synchronous values due to upstream
+ * constraints), this wrapper guarantees a fully asynchronous execution. It always returns a Promise,
+ * avoiding the "Zalgo" anti-pattern. Callers must always `await` the results.
+ *
+ * WARNING: No Error Fallbacks (Silent Downgrade Prevention)
+ * This wrapper deliberately DOES NOT catch and swallow WebCrypto errors to fall back to pure TS.
+ * Doing so could mask underlying security issues (e.g., malformed ciphertexts or unsupported keys)
+ * and enable downgrade attacks.
+ */
+function wrapMLKEMFallback(
+  wcKem: TRet<AsyncKEM>,
+  tsKem: TRet<KEM>,
+  checkSupport: () => boolean
+): TRet<AsyncKEM> {
+  const impl: AsyncKEM = {
+    info: tsKem.info,
+    lengths: tsKem.lengths,
+    async keygen(seed?: TArg<Uint8Array>, opts?: TArg<{ extractable?: boolean }>) {
+      if (checkSupport() && seed === undefined) {
+        return wcKem.keygen(seed, opts);
+      }
+      return Promise.resolve(tsKem.keygen(seed));
+    },
+    async getPublicKey(secretKey: TArg<Uint8Array | CryptoKey>) {
+      if (
+        checkSupport() &&
+        (!(secretKey instanceof Uint8Array) || secretKey.length === WEBCRYPTO_MLKEM_PKCS8_LENGTH)
+      ) {
+        return wcKem.getPublicKey(secretKey);
+      }
+      return Promise.resolve(tsKem.getPublicKey(secretKey as Uint8Array));
+    },
+    async encapsulate(publicKey: TArg<Uint8Array>, msg?: TArg<Uint8Array>) {
+      if (checkSupport() && msg === undefined) {
+        return wcKem.encapsulate(publicKey);
+      }
+      return Promise.resolve(tsKem.encapsulate(publicKey, msg));
+    },
+    async decapsulate(cipherText: TArg<Uint8Array>, secretKey: TArg<Uint8Array | CryptoKey>) {
+      if (
+        checkSupport() &&
+        (!(secretKey instanceof Uint8Array) || secretKey.length === WEBCRYPTO_MLKEM_PKCS8_LENGTH)
+      ) {
+        return wcKem.decapsulate(cipherText, secretKey);
+      }
+      return Promise.resolve(tsKem.decapsulate(cipherText, secretKey as Uint8Array));
+    },
+  };
+  return Object.freeze(impl) as unknown as TRet<AsyncKEM>;
+}
+
+/**
+ * Creates a DSA instance that opportunistically uses the WebCrypto backend if supported,
+ * but falls back to the pure TypeScript backend.
+ *
+ * Note on Asynchrony:
+ * Although the return type is typed as `TRet` (which allows synchronous values due to upstream
+ * constraints), this wrapper guarantees a fully asynchronous execution. It always returns a Promise,
+ * avoiding the "Zalgo" anti-pattern. Callers must always `await` the results.
+ *
+ * WARNING: No Error Fallbacks (Silent Downgrade Prevention)
+ * This wrapper deliberately DOES NOT catch and swallow WebCrypto errors to fall back to pure TS.
+ * Falling back on error could mask critical cryptographic verification failures or unsupported state
+ * and enable downgrade attacks.
+ */
+function wrapDSAFallback(
+  wcDsa: TRet<AsyncDSA>,
+  tsDsa: TRet<DSA>,
+  checkSupport: () => boolean
+): TRet<AsyncDSA> {
+  const dsaAny = tsDsa as any;
+  const impl: AsyncDSA = {
+    info: tsDsa.info,
+    securityLevel: dsaAny.securityLevel,
+    lengths: tsDsa.lengths,
+    async keygen(seed?: TArg<Uint8Array>, opts?: TArg<{ extractable?: boolean }>) {
+      if (checkSupport() && seed === undefined) {
+        return wcDsa.keygen(seed, opts);
+      }
+      return Promise.resolve(tsDsa.keygen(seed));
+    },
+    async getPublicKey(secretKey: TArg<Uint8Array | CryptoKey>) {
+      if (
+        checkSupport() &&
+        (!(secretKey instanceof Uint8Array) || secretKey.length === WEBCRYPTO_MLDSA_PKCS8_LENGTH)
+      ) {
+        return wcDsa.getPublicKey(secretKey);
+      }
+      return Promise.resolve(tsDsa.getPublicKey(secretKey as Uint8Array));
+    },
+    async sign(
+      msg: TArg<Uint8Array>,
+      secretKey: TArg<Uint8Array | CryptoKey>,
+      opts: TArg<SigOpts> = {}
+    ) {
+      if (
+        checkSupport() &&
+        (!(secretKey instanceof Uint8Array) || secretKey.length === WEBCRYPTO_MLDSA_PKCS8_LENGTH)
+      ) {
+        return wcDsa.sign(msg, secretKey, opts);
+      }
+      return Promise.resolve(tsDsa.sign(msg, secretKey as Uint8Array, opts));
+    },
+    async verify(
+      sig: TArg<Uint8Array>,
+      msg: TArg<Uint8Array>,
+      publicKey: TArg<Uint8Array>,
+      opts: TArg<VerOpts> = {}
+    ) {
+      if (checkSupport()) {
+        return wcDsa.verify(sig, msg, publicKey, opts);
+      }
+      return Promise.resolve(tsDsa.verify(sig, msg, publicKey, opts));
+    },
+    prehash: dsaAny.prehash,
+    internal: dsaAny.internal,
+  };
+  return Object.freeze(impl) as unknown as TRet<AsyncDSA>;
+}
+
+export const ml_kem512: TRet<AsyncKEM> = /* @__PURE__ */ wrapMLKEMFallback(
+  wc_ml_kem512,
+  ts_ml_kem512,
+  () => isMLKEM512Supported
+);
+export const ml_kem768: TRet<AsyncKEM> = /* @__PURE__ */ wrapMLKEMFallback(
+  wc_ml_kem768,
+  ts_ml_kem768,
+  () => isMLKEM768Supported
+);
+export const ml_kem1024: TRet<AsyncKEM> = /* @__PURE__ */ wrapMLKEMFallback(
+  wc_ml_kem1024,
+  ts_ml_kem1024,
+  () => isMLKEM1024Supported
+);
+
+export const ml_dsa44: TRet<AsyncDSA> = /* @__PURE__ */ wrapDSAFallback(
+  wc_ml_dsa44,
+  ts_ml_dsa44,
+  () => isMLDSA44Supported
+);
+export const ml_dsa65: TRet<AsyncDSA> = /* @__PURE__ */ wrapDSAFallback(
+  wc_ml_dsa65,
+  ts_ml_dsa65,
+  () => isMLDSA65Supported
+);
+export const ml_dsa87: TRet<AsyncDSA> = /* @__PURE__ */ wrapDSAFallback(
+  wc_ml_dsa87,
+  ts_ml_dsa87,
+  () => isMLDSA87Supported
+);
+
+/**
+ * Hybrid fallback implementation of X-Wing (MLKEM768-X25519).
+ *
+ * Note on Asynchrony:
+ * Although the return type is typed as `TRet` (which allows synchronous values),
+ * this wrapper guarantees a fully asynchronous execution. It always returns a Promise,
+ * avoiding the "Zalgo" anti-pattern. Callers must always `await` the results.
+ */
+const xWingImpl: AsyncKEM = {
+  info: ts_ml_kem768_x25519.info,
+  lengths: {
+    ...ts_ml_kem768_x25519.lengths,
+    secretKey: 1248, // Support both sizes in fallback (input can be 32 or 1248)
+  },
+  async keygen(seed?: TArg<Uint8Array>, opts?: TArg<{ extractable?: boolean }>) {
+    if (isXWingSupported && seed === undefined) {
+      return wc_ml_kem768_x25519.keygen(seed, opts);
+    }
+    return Promise.resolve(ts_ml_kem768_x25519.keygen(seed));
+  },
+  async getPublicKey(secretKey: TArg<Uint8Array | CryptoKey>) {
+    if (!(secretKey instanceof Uint8Array)) {
+      return wc_ml_kem768_x25519.getPublicKey(secretKey);
+    }
+    const skBytes = secretKey;
+    if (skBytes.length === 1248) {
+      return wc_ml_kem768_x25519.getPublicKey(secretKey);
+    }
+    return Promise.resolve(ts_ml_kem768_x25519.getPublicKey(secretKey));
+  },
+  async encapsulate(publicKey: TArg<Uint8Array>, msg?: TArg<Uint8Array>) {
+    if (isXWingSupported && msg === undefined) {
+      return wc_ml_kem768_x25519.encapsulate(publicKey);
+    }
+    return Promise.resolve(ts_ml_kem768_x25519.encapsulate(publicKey, msg));
+  },
+  async decapsulate(cipherText: TArg<Uint8Array>, secretKey: TArg<Uint8Array | CryptoKey>) {
+    if (isXWingSupported) {
+      return wc_ml_kem768_x25519.decapsulate(cipherText, secretKey);
+    }
+    return Promise.resolve(ts_ml_kem768_x25519.decapsulate(cipherText, secretKey as Uint8Array));
+  },
+};
+export const ml_kem768_x25519: TRet<AsyncKEM> = Object.freeze(
+  xWingImpl
+) as unknown as TRet<AsyncKEM>;
+
+export const XWing: TRet<AsyncKEM> = ml_kem768_x25519;
+export const MLKEM768X25519: TRet<AsyncKEM> = ml_kem768_x25519;

--- a/test/hybrid-integration.spec.ts
+++ b/test/hybrid-integration.spec.ts
@@ -1,0 +1,338 @@
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { ml_kem768_x25519 } from '../src/hybrid.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = __dirname.includes('compiled')
+  ? path.resolve(__dirname, '../../..')
+  : path.resolve(__dirname, '..');
+
+test.describe('noble-post-quantum WebCrypto Hybrid Integration', () => {
+  test.beforeEach(async ({ page }) => {
+    // 1. Create a mocked secure context with importmap and route all requests
+    await page.route('http://localhost:9999/**/*', async (route) => {
+      const url = route.request().url();
+      let relativePath = url.replace('http://localhost:9999/', '');
+
+      // Serve the main HTML page
+      if (relativePath === '') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'text/html',
+          body: `
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <script type="importmap">
+              {
+                "imports": {
+                  "@noble/hashes/": "/node_modules/@noble/hashes/",
+                  "@noble/curves/": "/node_modules/@noble/curves/"
+                }
+              }
+              </script>
+            </head>
+            <body>
+              <h1>Testing noble-post-quantum</h1>
+            </body>
+            </html>
+          `,
+        });
+        return;
+      }
+
+      // If the browser requests a .ts file, serve the compiled .js file instead
+      if (relativePath.endsWith('.ts')) {
+        relativePath = relativePath.replace(/\.ts$/, '.js');
+      }
+
+      const filePath = path.resolve(rootDir, relativePath);
+      const exists = fs.existsSync(filePath);
+      console.log(`[ROUTE DEBUG] url=${url} resolvedPath=${filePath} exists=${exists}`);
+
+      if (exists && fs.statSync(filePath).isFile()) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/javascript',
+          body: fs.readFileSync(filePath),
+        });
+      } else {
+        await route.fulfill({ status: 404 });
+      }
+    });
+
+    // 2. Inject a spy into window.crypto.subtle BEFORE the page loads
+    await page.addInitScript(() => {
+      (window as any).cryptoCalls = [];
+
+      if (window.crypto && window.crypto.subtle) {
+        const subtle = window.crypto.subtle;
+        const methodsToSpy = [
+          'generateKey',
+          'importKey',
+          'exportKey',
+          'encapsulateBits',
+          'decapsulateBits',
+        ];
+
+        methodsToSpy.forEach((method) => {
+          const original = (subtle as any)[method].bind(subtle);
+          (subtle as any)[method] = async function (...args: any[]) {
+            let algorithm = undefined;
+            if (method === 'importKey') {
+              algorithm = args[2]?.name || args[2];
+            } else if (method === 'exportKey') {
+              algorithm = args[1]?.algorithm?.name;
+            } else {
+              algorithm = args[0]?.name || args[0];
+            }
+            (window as any).cryptoCalls.push({ method, algorithm });
+            return original(...args);
+          };
+        });
+      }
+    });
+
+    page.on('console', (msg) => console.log('BROWSER CONSOLE:', msg.text()));
+    page.on('pageerror', (err) => console.log('BROWSER PAGEERROR:', err.message));
+    page.on('requestfailed', (req) =>
+      console.log('BROWSER REQUEST FAILED:', req.url(), req.failure()?.errorText)
+    );
+
+    // 3. Navigate to the secure context
+    await page.goto('http://localhost:9999/');
+  });
+
+  test('X-Wing keygen, encapsulate, and decapsulate hit WebCrypto and round-trip successfully', async ({
+    page,
+  }) => {
+    const result = await page.evaluate(async () => {
+      try {
+        const mod = await import('http://localhost:9999/webcrypto_with_fallback.js');
+        const kem = mod.MLKEM768X25519;
+
+        // 1. Key Generation
+        const keyPair = await kem.keygen();
+        (window as any).testSecretKey = keyPair.secretKey;
+
+        // 2. Encapsulation
+        const { cipherText, sharedSecret: senderSecret } = await kem.encapsulate(keyPair.publicKey);
+
+        // 3. Decapsulation
+        const receiverSecret = await kem.decapsulate(cipherText, (window as any).testSecretKey);
+
+        // 4. Verify Correctness
+        const senderBytes = new Uint8Array(senderSecret);
+        const receiverBytes = new Uint8Array(receiverSecret);
+        const isMatch =
+          senderBytes.length === receiverBytes.length &&
+          senderBytes.every((val, i) => val === receiverBytes[i]);
+
+        return {
+          success: true,
+          isMatch,
+          recordedCalls: (window as any).cryptoCalls,
+          publicKeyLength: keyPair.publicKey.byteLength,
+          isCryptoKey: typeof keyPair.secretKey === 'object' && keyPair.secretKey.type === 'private',
+          cipherTextLength: cipherText.byteLength,
+        };
+      } catch (error) {
+        return { success: false, error: (error as Error).message };
+      }
+    });
+
+    expect(result.success, `Execution failed: ${result.error}`).toBe(true);
+    expect(result.isMatch, 'Sender and Receiver shared secrets do not match!').toBe(true);
+    expect(result.publicKeyLength).toBe(1216);
+    // expect(result.secretKeyLength).toBe(1248);
+    // expect(result.isCryptoKey).toBe(true);
+    expect(result.cipherTextLength).toBe(1120);
+
+    // Verify SubtleCrypto was called with the correct algorithm name
+    expect(result.recordedCalls).toContainEqual({ method: 'generateKey', algorithm: 'MLKEM768-X25519' });
+    expect(result.recordedCalls).toContainEqual({ method: 'exportKey', algorithm: 'MLKEM768-X25519' });
+    expect(result.recordedCalls).toContainEqual({ method: 'importKey', algorithm: 'MLKEM768-X25519' });
+    expect(result.recordedCalls).toContainEqual({ method: 'encapsulateBits', algorithm: 'MLKEM768-X25519' });
+    expect(result.recordedCalls).toContainEqual({ method: 'decapsulateBits', algorithm: 'MLKEM768-X25519' });
+  });
+
+  test('Cross-backend Interop: TS KeyGen/Decapsulate <-> WebCrypto Encapsulate - X-Wing', async ({ page }) => {
+    // 1. (Node) Generate a keyPair using pure TS
+    const kemTs = ml_kem768_x25519;
+    const seed = new Uint8Array(32);
+    seed.fill(3);
+    const keyPairTs = kemTs.keygen(seed);
+    
+    // We must serialize the publicKey to an array to pass it to page.evaluate
+    const publicKeyArray = Array.from(keyPairTs.publicKey);
+    
+    const result = await page.evaluate(async ({ pubKey }) => {
+      try {
+        const mod = await import('http://localhost:9999/webcrypto_with_fallback.js');
+        const kemWc = mod.MLKEM768X25519;
+        
+        // 2. (Browser) WebCrypto Encapsulate
+        const publicKey = new Uint8Array(pubKey);
+        const { cipherText, sharedSecret } = await kemWc.encapsulate(publicKey);
+        
+        return {
+          success: true,
+          cipherText: Array.from(cipherText),
+          sharedSecret: Array.from(sharedSecret),
+        };
+      } catch (error) {
+        return { success: false, error: (error as Error).message };
+      }
+    }, { pubKey: publicKeyArray });
+    
+    expect(result.success, `WebCrypto encapsulate failed: ${result.error}`).toBe(true);
+    
+    // 3. (Node) TS Decapsulate
+    const cipherTextTs = new Uint8Array(result.cipherText);
+    const decapsulatedSecretTs = kemTs.decapsulate(cipherTextTs, keyPairTs.secretKey);
+    
+    const webCryptoSecret = new Uint8Array(result.sharedSecret);
+    
+    // Assert they match
+    expect(decapsulatedSecretTs).toEqual(webCryptoSecret);
+  });
+
+  test('Cross-backend Interop: WebCrypto KeyGen/Decapsulate <-> TS Encapsulate - X-Wing', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      try {
+        const mod = await import('http://localhost:9999/webcrypto_with_fallback.js');
+        const kemWc = mod.MLKEM768X25519;
+        
+        // 1. (Browser) WebCrypto KeyGen with extractable: true
+        const keyPair = await kemWc.keygen(undefined, { extractable: true });
+        
+        return {
+          success: true,
+          publicKey: Array.from(keyPair.publicKey),
+          secretKey: Array.from(keyPair.secretKey),
+        };
+      } catch (error) {
+        return { success: false, error: (error as Error).message };
+      }
+    });
+    
+    expect(result.success, `WebCrypto keygen failed: ${result.error}`).toBe(true);
+    
+    // 2. (Node) TS Encapsulate
+    const kemTs = ml_kem768_x25519;
+    const pubKeyTs = new Uint8Array(result.publicKey);
+    
+    const { cipherText, sharedSecret: tsSharedSecret } = kemTs.encapsulate(pubKeyTs);
+    
+    const cipherTextArray = Array.from(cipherText);
+    const secretKeyArray = result.secretKey;
+    
+    // 3. (Browser) WebCrypto Decapsulate
+    const decapsResult = await page.evaluate(async ({ cText, sKey }) => {
+      try {
+         const mod = await import('http://localhost:9999/webcrypto_with_fallback.js');
+         const kemWc = mod.MLKEM768X25519;
+         const cipherTextBytes = new Uint8Array(cText);
+         const secretKeyBytes = new Uint8Array(sKey);
+         
+         const wcDecapsulatedSecret = await kemWc.decapsulate(cipherTextBytes, secretKeyBytes);
+         return {
+           success: true,
+           wcSharedSecret: Array.from(wcDecapsulatedSecret)
+         };
+      } catch(error) {
+         return { success: false, error: (error as Error).message };
+      }
+    }, { cText: cipherTextArray, sKey: secretKeyArray });
+    
+    expect(decapsResult.success, `WebCrypto decapsulate failed: ${decapsResult.error}`).toBe(true);
+    
+    const webCryptoSecret = new Uint8Array(decapsResult.wcSharedSecret);
+    expect(tsSharedSecret).toEqual(webCryptoSecret);
+  });
+
+  test('Providing a seed bypasses WebCrypto and falls back to pure TS', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const mod = await import('http://localhost:9999/webcrypto_with_fallback.js');
+      const kem = mod.MLKEM768X25519;
+
+      (window as any).cryptoCalls = [];
+
+      const seed = new Uint8Array(32);
+      seed.fill(1);
+
+      const keyPairPromise = kem.keygen(seed);
+      const isPromise = keyPairPromise instanceof Promise;
+      const keyPair = await keyPairPromise;
+
+      return {
+        isPromise,
+        recordedCalls: (window as any).cryptoCalls,
+      };
+    });
+
+    expect(result.isPromise).toBe(true);
+    expect(result.recordedCalls.length).toBe(0);
+  });
+
+  test('throws if WebCrypto throws an error instead of falling back', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      try {
+        const mod = await import('http://localhost:9999/webcrypto_with_fallback.js');
+        const kem = mod.MLKEM768X25519;
+
+        // Mock failure on encapsulateBits
+        window.crypto.subtle.encapsulateBits = async () => {
+          throw new DOMException('Simulated native failure', 'NotSupportedError');
+        };
+
+        (window as any).cryptoCalls = [];
+
+        const keyPair = await kem.keygen();
+        await kem.encapsulate(keyPair.publicKey);
+
+        return {
+          success: true,
+          recordedCalls: (window as any).cryptoCalls,
+        };
+      } catch (error) {
+        return { success: false, error: (error as Error).message };
+      }
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Simulated native failure');
+  });
+
+  test('pure webcrypto.js throws when deterministic/custom inputs are used', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const { ml_kem768_x25519 } = await import('http://localhost:9999/webcrypto.js');
+      let keygenThrew = false;
+      let encapsulateThrew = false;
+      let decapsulateThrew = false;
+      try {
+        await ml_kem768_x25519.keygen(new Uint8Array(32));
+      } catch (e) {
+        keygenThrew = true;
+      }
+      try {
+        const keyPair = await ml_kem768_x25519.keygen();
+        await ml_kem768_x25519.encapsulate(keyPair.publicKey, new Uint8Array(64));
+      } catch (e) {
+        encapsulateThrew = true;
+      }
+      try {
+        await ml_kem768_x25519.decapsulate(new Uint8Array(1120), new Uint8Array(32));
+      } catch (e) {
+        decapsulateThrew = true;
+      }
+      return { keygenThrew, encapsulateThrew, decapsulateThrew };
+    });
+    expect(result.keygenThrew).toBe(true);
+    expect(result.encapsulateThrew).toBe(true);
+    expect(result.decapsulateThrew).toBe(true);
+  });
+
+});

--- a/test/ml-dsa-integration.spec.ts
+++ b/test/ml-dsa-integration.spec.ts
@@ -1,0 +1,361 @@
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { ml_dsa44, ml_dsa65, ml_dsa87 } from '../src/ml-dsa.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = __dirname.includes('compiled')
+  ? path.resolve(__dirname, '../../..')
+  : path.resolve(__dirname, '..');
+
+test.describe('noble-post-quantum WebCrypto ML-DSA Integration', () => {
+  test.beforeEach(async ({ page }) => {
+    // 1. Create a mocked secure context with importmap and route all requests
+    await page.route('http://localhost:9999/**/*', async (route) => {
+      const url = route.request().url();
+      let relativePath = url.replace('http://localhost:9999/', '');
+
+      // Serve the main HTML page
+      if (relativePath === '') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'text/html',
+          body: `
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <script type="importmap">
+              {
+                "imports": {
+                  "@noble/hashes/": "/node_modules/@noble/hashes/",
+                  "@noble/curves/": "/node_modules/@noble/curves/"
+                }
+              }
+              </script>
+            </head>
+            <body>
+              <h1>Testing noble-post-quantum ML-DSA</h1>
+            </body>
+            </html>
+          `,
+        });
+        return;
+      }
+
+      // If the browser requests a .ts file, serve the compiled .js file instead
+      if (relativePath.endsWith('.ts')) {
+        relativePath = relativePath.replace(/\.ts$/, '.js');
+      }
+
+      const filePath = path.resolve(rootDir, relativePath);
+      const exists = fs.existsSync(filePath);
+
+      if (exists && fs.statSync(filePath).isFile()) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/javascript',
+          body: fs.readFileSync(filePath),
+        });
+      } else {
+        await route.fulfill({ status: 404 });
+      }
+    });
+
+    // 2. Inject a spy into window.crypto.subtle BEFORE the page loads
+    await page.addInitScript(() => {
+      (window as any).cryptoCalls = [];
+
+      if (window.crypto && window.crypto.subtle) {
+        const subtle = window.crypto.subtle;
+        const methodsToSpy = ['generateKey', 'importKey', 'exportKey', 'sign', 'verify'];
+
+        methodsToSpy.forEach((method) => {
+          const original = (subtle as any)[method].bind(subtle);
+          (subtle as any)[method] = async function (...args: any[]) {
+            let algorithm = undefined;
+            if (method === 'importKey') {
+              algorithm = args[2]?.name || args[2];
+            } else if (method === 'exportKey') {
+              algorithm = args[1]?.algorithm?.name;
+            } else {
+              algorithm = args[0]?.name || args[0];
+            }
+            (window as any).cryptoCalls.push({ method, algorithm });
+            return original(...args);
+          };
+        });
+      }
+    });
+
+    page.on('console', (msg) => console.log('BROWSER CONSOLE:', msg.text()));
+    page.on('pageerror', (err) => console.log('BROWSER PAGEERROR:', err.message));
+
+    // 3. Navigate to the secure context
+    await page.goto('http://localhost:9999/');
+  });
+
+  const parameterSets = [
+    { name: 'ml_dsa44', publicKeyLength: 1312 },
+    { name: 'ml_dsa65', publicKeyLength: 1952 },
+    { name: 'ml_dsa87', publicKeyLength: 2592 },
+  ];
+
+  for (const { name, publicKeyLength } of parameterSets) {
+    test(`keygen, sign, and verify hit WebCrypto and round-trip successfully - ${name}`, async ({
+      page,
+    }) => {
+      const result = await page.evaluate(
+        async ({ instanceName }) => {
+          try {
+            const mod = await import('http://localhost:9999/webcrypto_with_fallback.js');
+            const dsa = (mod as any)[instanceName];
+
+            // 1. Generate Keys (async)
+            const keyPair = await dsa.keygen();
+            (window as any).testSecretKey = keyPair.secretKey;
+
+            const message = new Uint8Array([1, 2, 3, 4, 5]);
+
+            // 2. Sign
+            const sig = await dsa.sign(message, (window as any).testSecretKey);
+
+            // 3. Verify
+            const isValid = await dsa.verify(sig, message, keyPair.publicKey);
+
+            return {
+              success: true,
+              isValid,
+              recordedCalls: (window as any).cryptoCalls,
+              publicKeyLength: keyPair.publicKey.byteLength,
+              isCryptoKey: typeof keyPair.secretKey === 'object' && keyPair.secretKey.type === 'private',
+            };
+          } catch (error) {
+            return { success: false, error: (error as Error).message };
+          }
+        },
+        { instanceName: name }
+      );
+
+      expect(result.success, `Execution failed: ${result.error}`).toBe(true);
+      expect(result.isValid, 'Signature verification failed!').toBe(true);
+      expect(result.publicKeyLength).toBe(publicKeyLength);
+      // expect(result.secretKeyLength).toBe(54); // WebCrypto PKCS8 format length for private keys
+      // expect(result.isCryptoKey).toBe(true);
+
+      const algName = name.replace('ml_dsa', 'ML-DSA-');
+      expect(result.recordedCalls).toContainEqual({ method: 'generateKey', algorithm: algName });
+      expect(result.recordedCalls).toContainEqual({ method: 'importKey', algorithm: algName });
+      expect(result.recordedCalls).toContainEqual({ method: 'sign', algorithm: algName });
+      expect(result.recordedCalls).toContainEqual({ method: 'verify', algorithm: algName });
+    });
+
+    test(`Cross-backend Interop: TS KeyGen/Verify <-> WebCrypto Sign - ${name}`, async ({ page }) => {
+      // 1. (Node) Generate a keyPair using pure TS
+      const tsMod = { ml_dsa44, ml_dsa65, ml_dsa87 } as any;
+      const dsaTs = tsMod[name];
+      const seed = new Uint8Array(32);
+      seed.fill(4);
+      const keyPairTs = dsaTs.keygen(seed);
+      
+      const message = new Uint8Array([1, 2, 3, 4, 5]);
+      
+      const secretKeyArray = Array.from(keyPairTs.secretKey);
+      const messageArray = Array.from(message);
+      
+      // 2. (Browser) WebCrypto Sign
+      const result = await page.evaluate(async ({ instanceName, sKey, msg }) => {
+        try {
+          const mod = await import('http://localhost:9999/webcrypto_with_fallback.js');
+          const dsaWc = (mod as any)[instanceName];
+          
+          const secretKey = new Uint8Array(sKey);
+          const messageBytes = new Uint8Array(msg);
+          
+          const signature = await dsaWc.sign(messageBytes, secretKey);
+          
+          return {
+            success: true,
+            signature: Array.from(signature)
+          };
+        } catch (error) {
+          return { success: false, error: (error as Error).message };
+        }
+      }, { instanceName: name, sKey: secretKeyArray, msg: messageArray });
+      
+      expect(result.success, `WebCrypto sign failed: ${result.error}`).toBe(true);
+      
+      // 3. (Node) TS Verify
+      const signatureTs = new Uint8Array(result.signature);
+      const isValid = dsaTs.verify(signatureTs, message, keyPairTs.publicKey);
+      
+      expect(isValid).toBe(true);
+    });
+
+    test(`Cross-backend Interop: WebCrypto KeyGen/Verify <-> TS Sign - ${name}`, async ({ page }) => {
+      const message = new Uint8Array([1, 2, 3, 4, 5]);
+      const messageArray = Array.from(message);
+      
+      // 1. (Browser) WebCrypto KeyGen
+      const result = await page.evaluate(async ({ instanceName }) => {
+        try {
+          const mod = await import('http://localhost:9999/webcrypto_with_fallback.js');
+          const dsaWc = (mod as any)[instanceName];
+          
+          const keyPair = await dsaWc.keygen(undefined, { extractable: true });
+          
+          return {
+            success: true,
+            publicKey: Array.from(keyPair.publicKey),
+            secretKey: Array.from(keyPair.secretKey as Uint8Array),
+          };
+        } catch (error) {
+          return { success: false, error: (error as Error).message };
+        }
+      }, { instanceName: name });
+      
+      expect(result.success, `WebCrypto keygen failed: ${result.error}`).toBe(true);
+      
+      // 2. (Node) TS Sign
+      const tsMod = { ml_dsa44, ml_dsa65, ml_dsa87 } as any;
+      const dsaTs = tsMod[name];
+      const secretKeyTs = new Uint8Array(result.secretKey);
+      
+      const derivedSecretKeyTs = dsaTs.keygen(secretKeyTs.subarray(22)).secretKey;
+      const signatureTs = dsaTs.sign(message, derivedSecretKeyTs);
+      const signatureArray = Array.from(signatureTs);
+      const publicKeyArray = result.publicKey;
+      
+      // 3. (Browser) WebCrypto Verify
+      const verifyResult = await page.evaluate(async ({ instanceName, sig, msg, pubKey }) => {
+        try {
+           const mod = await import('http://localhost:9999/webcrypto_with_fallback.js');
+           const dsaWc = (mod as any)[instanceName];
+           
+           const signatureBytes = new Uint8Array(sig);
+           const messageBytes = new Uint8Array(msg);
+           const publicKeyBytes = new Uint8Array(pubKey);
+           
+           const isValid = await dsaWc.verify(signatureBytes, messageBytes, publicKeyBytes);
+           return {
+             success: true,
+             isValid
+           };
+        } catch(error) {
+           return { success: false, error: (error as Error).message };
+        }
+      }, { instanceName: name, sig: signatureArray, msg: messageArray, pubKey: publicKeyArray });
+      
+      expect(verifyResult.success, `WebCrypto verify failed: ${verifyResult.error}`).toBe(true);
+      expect(verifyResult.isValid).toBe(true);
+    });
+  }
+
+  test('Providing a seed bypasses WebCrypto and falls back to pure TS', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const { ml_dsa44 } = await import('http://localhost:9999/webcrypto_with_fallback.js');
+
+      (window as any).cryptoCalls = [];
+
+      const seed = new Uint8Array(32);
+      seed.fill(2);
+
+      const keyPairPromise = ml_dsa44.keygen(seed);
+      const isPromise = keyPairPromise instanceof Promise;
+      const keyPair = await keyPairPromise;
+
+      return {
+        isPromise,
+        recordedCalls: (window as any).cryptoCalls,
+        secretKeyLen: keyPair.secretKey.byteLength,
+      };
+    });
+
+    expect(result.isPromise).toBe(true);
+    expect(result.recordedCalls.length).toBe(0);
+    expect(result.secretKeyLen).toBeGreaterThan(1000); // TS secretKey is large
+  });
+
+  test('throws if WebCrypto sign throws an error instead of falling back', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      try {
+        const { ml_dsa44 } = await import('http://localhost:9999/webcrypto_with_fallback.js');
+
+        // Force native sign to fail
+        window.crypto.subtle.sign = async () => {
+          throw new DOMException('Simulated native failure', 'NotSupportedError');
+        };
+
+        (window as any).cryptoCalls = [];
+
+        const keyPair = await ml_dsa44.keygen();
+        const message = new Uint8Array([1, 2, 3, 4, 5]);
+        await ml_dsa44.sign(message, keyPair.secretKey);
+
+        return {
+          success: true,
+          recordedCalls: (window as any).cryptoCalls,
+        };
+      } catch (error) {
+        return { success: false, error: (error as Error).message };
+      }
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Simulated native failure');
+  });
+
+  test('Context Testing: signing/verifying with context string fallback/handling', async ({
+    page,
+  }) => {
+    const result = await page.evaluate(async () => {
+      try {
+        const { ml_dsa44 } = await import('http://localhost:9999/webcrypto_with_fallback.js');
+
+        (window as any).cryptoCalls = [];
+
+        const keyPair = await ml_dsa44.keygen();
+        const message = new Uint8Array([1, 2, 3, 4, 5]);
+        const context = new TextEncoder().encode("app-context-domain-separator");
+
+        const sig = await ml_dsa44.sign(message, keyPair.secretKey, { context });
+        const isValid = await ml_dsa44.verify(sig, message, keyPair.publicKey, { context });
+
+        return {
+          success: true,
+          isValid,
+          recordedCalls: (window as any).cryptoCalls,
+        };
+      } catch (error) {
+        return { success: false, error: (error as Error).message };
+      }
+    });
+
+    expect(result.success, `Execution failed: ${result.error}`).toBe(true);
+    expect(result.isValid).toBe(true);
+    expect(result.recordedCalls).toContainEqual({ method: 'generateKey', algorithm: 'ML-DSA-44' });
+    expect(result.recordedCalls).toContainEqual({ method: 'sign', algorithm: 'ML-DSA-44' });
+    expect(result.recordedCalls).toContainEqual({ method: 'verify', algorithm: 'ML-DSA-44' });
+  });
+
+  test('pure webcrypto.js throws when deterministic/custom inputs are used', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const { ml_dsa44 } = await import('http://localhost:9999/webcrypto.js');
+      let keygenThrew = false;
+      let prehashThrew = false;
+      try {
+        await ml_dsa44.keygen(new Uint8Array(32));
+      } catch (e) {
+        keygenThrew = true;
+      }
+      try {
+        await ml_dsa44.prehash();
+      } catch (e) {
+        prehashThrew = true;
+      }
+      return { keygenThrew, prehashThrew };
+    });
+    expect(result.keygenThrew).toBe(true);
+    expect(result.prehashThrew).toBe(true);
+  });
+});

--- a/test/ml-kem-integration.spec.ts
+++ b/test/ml-kem-integration.spec.ts
@@ -1,0 +1,348 @@
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { ml_kem512, ml_kem768, ml_kem1024 } from '../src/ml-kem.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = __dirname.includes('compiled')
+  ? path.resolve(__dirname, '../../..')
+  : path.resolve(__dirname, '..');
+
+test.describe('noble-post-quantum WebCrypto PQC Integration', () => {
+  test.beforeEach(async ({ page }) => {
+    // 1. Create a mocked secure context with importmap and route all requests
+    await page.route('http://localhost:9999/**/*', async (route) => {
+      const url = route.request().url();
+      let relativePath = url.replace('http://localhost:9999/', '');
+
+      // Serve the main HTML page
+      if (relativePath === '') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'text/html',
+          body: `
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <script type="importmap">
+              {
+                "imports": {
+                  "@noble/hashes/": "/node_modules/@noble/hashes/",
+                  "@noble/curves/": "/node_modules/@noble/curves/"
+                }
+              }
+              </script>
+            </head>
+            <body>
+              <h1>Testing noble-post-quantum</h1>
+            </body>
+            </html>
+          `,
+        });
+        return;
+      }
+
+      // If the browser requests a .ts file, serve the compiled .js file instead
+      if (relativePath.endsWith('.ts')) {
+        relativePath = relativePath.replace(/\.ts$/, '.js');
+      }
+
+      const filePath = path.resolve(rootDir, relativePath);
+      const exists = fs.existsSync(filePath);
+      console.log(`[ROUTE DEBUG] url=${url} resolvedPath=${filePath} exists=${exists}`);
+
+      if (exists && fs.statSync(filePath).isFile()) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/javascript',
+          body: fs.readFileSync(filePath),
+        });
+      } else {
+        await route.fulfill({ status: 404 });
+      }
+    });
+
+    // 2. Inject a spy into window.crypto.subtle BEFORE the page loads
+    await page.addInitScript(() => {
+      (window as any).cryptoCalls = [];
+
+      if (window.crypto && window.crypto.subtle) {
+        const subtle = window.crypto.subtle;
+        const methodsToSpy = [
+          'generateKey',
+          'importKey',
+          'exportKey',
+          'encapsulateBits',
+          'decapsulateBits',
+        ];
+
+        methodsToSpy.forEach((method) => {
+          const original = (subtle as any)[method].bind(subtle);
+          (subtle as any)[method] = async function (...args: any[]) {
+            let algorithm = undefined;
+            if (method === 'importKey') {
+              algorithm = args[2]?.name || args[2];
+            } else if (method === 'exportKey') {
+              algorithm = args[1]?.algorithm?.name;
+            } else {
+              algorithm = args[0]?.name || args[0];
+            }
+            (window as any).cryptoCalls.push({ method, algorithm });
+            return original(...args);
+          };
+        });
+      }
+    });
+
+    page.on('console', (msg) => console.log('BROWSER CONSOLE:', msg.text()));
+    page.on('pageerror', (err) => console.log('BROWSER PAGEERROR:', err.message));
+    page.on('requestfailed', (req) =>
+      console.log('BROWSER REQUEST FAILED:', req.url(), req.failure()?.errorText)
+    );
+
+    // 3. Navigate to the secure context
+    await page.goto('http://localhost:9999/');
+
+    const supportsType = await page.evaluate(() => typeof (window.crypto.subtle as any).supports);
+    console.log('[BROWSER INFO] window.crypto.subtle.supports type:', supportsType);
+  });
+
+  const parameterSets = [
+    { name: 'ml_kem512', publicKeyLength: 800, isNativeSupported: false },
+    { name: 'ml_kem768', publicKeyLength: 1184, isNativeSupported: true },
+    { name: 'ml_kem1024', publicKeyLength: 1568, isNativeSupported: true },
+  ];
+
+  for (const { name, publicKeyLength, isNativeSupported } of parameterSets) {
+    test(`keygen, encapsulate, and decapsulate hit WebCrypto and round-trip successfully - ${name}`, async ({
+      page,
+    }) => {
+      const result = await page.evaluate(
+        async ({ instanceName }) => {
+          try {
+            // Dynamically import the ES module directly using the importmap
+            const mod = await import('http://localhost:9999/webcrypto_with_fallback.js');
+            const kem = (mod as any)[instanceName];
+
+            // 1. Generate Keys (async)
+            const keyPair = await kem.keygen();
+            (window as any).testSecretKey = keyPair.secretKey;
+
+            // 2. Encapsulate
+            const { cipherText, sharedSecret: senderSecret } = await kem.encapsulate(
+              keyPair.publicKey
+            );
+
+            // 3. Decapsulate
+            const receiverSecret = await kem.decapsulate(cipherText, (window as any).testSecretKey);
+
+            // 4. Verify Correctness (Shared secrets must match)
+            const senderBytes = new Uint8Array(senderSecret);
+            const receiverBytes = new Uint8Array(receiverSecret);
+
+            const isMatch =
+              senderBytes.length === receiverBytes.length &&
+              senderBytes.every((val, i) => val === receiverBytes[i]);
+
+            return {
+              success: true,
+              isMatch,
+              recordedCalls: (window as any).cryptoCalls,
+              publicKeyLength: keyPair.publicKey.byteLength,
+              isCryptoKey: typeof keyPair.secretKey === 'object' && keyPair.secretKey.type === 'private',
+            };
+          } catch (error) {
+            return { success: false, error: (error as Error).message };
+          }
+        },
+        { instanceName: name }
+      );
+
+      expect(result.success, `Execution failed: ${result.error}`).toBe(true);
+      expect(result.isMatch, 'Sender and Receiver shared secrets do not match!').toBe(true);
+      expect(result.publicKeyLength).toBe(publicKeyLength);
+      // expect(result.isCryptoKey).toBe(true);
+
+      if (isNativeSupported) {
+        const algName = name.replace('ml_kem', 'ML-KEM-');
+        expect(result.recordedCalls).toContainEqual({ method: 'generateKey', algorithm: algName });
+        expect(result.recordedCalls).toContainEqual({ method: 'importKey', algorithm: algName });
+        expect(result.recordedCalls).toContainEqual({ method: 'encapsulateBits', algorithm: algName });
+        expect(result.recordedCalls).toContainEqual({ method: 'decapsulateBits', algorithm: algName });
+      } else {
+        expect(result.recordedCalls.some((c: any) => c.method === 'encapsulateBits')).toBe(false);
+        expect(result.recordedCalls.some((c: any) => c.method === 'decapsulateBits')).toBe(false);
+      }
+    });
+
+    test(`Cross-backend Interop: TS KeyGen/Decapsulate <-> WebCrypto Encapsulate - ${name}`, async ({ page }) => {
+      // 1. (Node) Generate a keyPair using pure TS
+      const tsMod = { ml_kem512, ml_kem768, ml_kem1024 } as any;
+      const kemTs = tsMod[name];
+      const seed = new Uint8Array(64);
+      seed.fill(3);
+      const keyPairTs = kemTs.keygen(seed);
+      
+      // We must serialize the publicKey to an array to pass it to page.evaluate
+      const publicKeyArray = Array.from(keyPairTs.publicKey);
+      
+      const result = await page.evaluate(async ({ instanceName, pubKey }) => {
+        try {
+          const mod = await import('http://localhost:9999/webcrypto_with_fallback.js');
+          const kemWc = (mod as any)[instanceName];
+          
+          // 2. (Browser) WebCrypto Encapsulate
+          const publicKey = new Uint8Array(pubKey);
+          const { cipherText, sharedSecret } = await kemWc.encapsulate(publicKey);
+          
+          return {
+            success: true,
+            cipherText: Array.from(cipherText),
+            sharedSecret: Array.from(sharedSecret),
+          };
+        } catch (error) {
+          return { success: false, error: (error as Error).message };
+        }
+      }, { instanceName: name, pubKey: publicKeyArray });
+      
+      expect(result.success, `WebCrypto encapsulate failed: ${result.error}`).toBe(true);
+      
+      // 3. (Node) TS Decapsulate
+      const cipherTextTs = new Uint8Array(result.cipherText);
+      const decapsulatedSecretTs = kemTs.decapsulate(cipherTextTs, keyPairTs.secretKey);
+      
+      const webCryptoSecret = new Uint8Array(result.sharedSecret);
+      
+      // Assert they match
+      expect(decapsulatedSecretTs).toEqual(webCryptoSecret);
+    });
+
+    test(`Cross-backend Interop: WebCrypto KeyGen/Decapsulate <-> TS Encapsulate - ${name}`, async ({ page }) => {
+      const result = await page.evaluate(async ({ instanceName }) => {
+        try {
+          const mod = await import('http://localhost:9999/webcrypto_with_fallback.js');
+          const kemWc = (mod as any)[instanceName];
+          
+          // 1. (Browser) WebCrypto KeyGen with extractable: true
+          const keyPair = await kemWc.keygen(undefined, { extractable: true });
+          
+          return {
+            success: true,
+            publicKey: Array.from(keyPair.publicKey),
+            secretKey: Array.from(keyPair.secretKey),
+          };
+        } catch (error) {
+          return { success: false, error: (error as Error).message };
+        }
+      }, { instanceName: name });
+      
+      expect(result.success, `WebCrypto keygen failed: ${result.error}`).toBe(true);
+      
+      // 2. (Node) TS Encapsulate
+      const tsMod = { ml_kem512, ml_kem768, ml_kem1024 } as any;
+      const kemTs = tsMod[name];
+      const pubKeyTs = new Uint8Array(result.publicKey);
+      
+      const { cipherText, sharedSecret: tsSharedSecret } = kemTs.encapsulate(pubKeyTs);
+      
+      const cipherTextArray = Array.from(cipherText);
+      const secretKeyArray = result.secretKey;
+      
+      // 3. (Browser) WebCrypto Decapsulate
+      const decapsResult = await page.evaluate(async ({ instanceName, cText, sKey }) => {
+        try {
+           const mod = await import('http://localhost:9999/webcrypto_with_fallback.js');
+           const kemWc = (mod as any)[instanceName];
+           const cipherTextBytes = new Uint8Array(cText);
+           const secretKeyBytes = new Uint8Array(sKey);
+           
+           const wcDecapsulatedSecret = await kemWc.decapsulate(cipherTextBytes, secretKeyBytes);
+           return {
+             success: true,
+             wcSharedSecret: Array.from(wcDecapsulatedSecret)
+           };
+        } catch(error) {
+           return { success: false, error: (error as Error).message };
+        }
+      }, { instanceName: name, cText: cipherTextArray, sKey: secretKeyArray });
+      
+      expect(decapsResult.success, `WebCrypto decapsulate failed: ${decapsResult.error}`).toBe(true);
+      
+      const webCryptoSecret = new Uint8Array(decapsResult.wcSharedSecret);
+      expect(tsSharedSecret).toEqual(webCryptoSecret);
+    });
+  }
+
+  test('Providing a seed bypasses WebCrypto and falls back to pure TS', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const { ml_kem768 } = await import('http://localhost:9999/webcrypto_with_fallback.js');
+
+      (window as any).cryptoCalls = [];
+
+      const seed = new Uint8Array(64);
+      seed.fill(1);
+
+      const keyPairPromise = ml_kem768.keygen(seed);
+      const isPromise = keyPairPromise instanceof Promise;
+      const keyPair = await keyPairPromise;
+
+      return {
+        isPromise,
+        recordedCalls: (window as any).cryptoCalls,
+      };
+    });
+
+    expect(result.isPromise).toBe(true);
+    expect(result.recordedCalls.length).toBe(0);
+  });
+
+  test('throws if WebCrypto throws an error instead of falling back', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      try {
+        const { ml_kem768 } = await import('http://localhost:9999/webcrypto_with_fallback.js');
+
+        window.crypto.subtle.encapsulateBits = async () => {
+          throw new DOMException('Simulated native failure', 'NotSupportedError');
+        };
+
+        (window as any).cryptoCalls = [];
+
+        const keyPair = await ml_kem768.keygen();
+        await ml_kem768.encapsulate(keyPair.publicKey);
+
+        return {
+          success: true,
+          recordedCalls: (window as any).cryptoCalls,
+        };
+      } catch (error) {
+        return { success: false, error: (error as Error).message };
+      }
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Simulated native failure');
+  });
+
+  test('pure webcrypto.js throws when deterministic/custom inputs are used', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const { ml_kem768 } = await import('http://localhost:9999/webcrypto.js');
+      let keygenThrew = false;
+      let encapsulateThrew = false;
+      try {
+        await ml_kem768.keygen(new Uint8Array(64));
+      } catch (e) {
+        keygenThrew = true;
+      }
+      try {
+        const keyPair = await ml_kem768.keygen();
+        await ml_kem768.encapsulate(keyPair.publicKey, new Uint8Array(32));
+      } catch (e) {
+        encapsulateThrew = true;
+      }
+      return { keygenThrew, encapsulateThrew };
+    });
+    expect(result.keygenThrew).toBe(true);
+    expect(result.encapsulateThrew).toBe(true);
+  });
+});

--- a/test/webcrypto-headers.spec.ts
+++ b/test/webcrypto-headers.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+import { ML_KEM_OIDS, ML_DSA_OIDS } from '../src/webcrypto.ts';
+import { wrapSPKI, unwrapSPKI } from '../src/utils.ts';
+
+test.describe('WebCrypto Native SPKI Headers Validation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('https://pqc-test.local/', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<html><body>PQC Testing Sandbox</body></html>',
+      });
+    });
+    await page.goto('https://pqc-test.local/');
+  });
+
+  const KEM_ALGS = [
+    { name: 'ML-KEM-512', k: 2 },
+    { name: 'ML-KEM-768', k: 3 },
+    { name: 'ML-KEM-1024', k: 4 },
+  ];
+
+  for (const alg of KEM_ALGS) {
+    test(`Native ${alg.name} SPKI can be unwrapped and re-wrapped to match exactly`, async ({ page }) => {
+      const spkiArray = await page.evaluate(async ({ algName }) => {
+        try {
+          const kp = await window.crypto.subtle.generateKey(
+            { name: algName } as any,
+            true,
+            ['encapsulateBits', 'decapsulateBits'] as any
+          );
+          const spkiBuffer = await window.crypto.subtle.exportKey('spki', kp.publicKey);
+          return Array.from(new Uint8Array(spkiBuffer as ArrayBuffer));
+        } catch (error) {
+          if ((error as Error).name === 'NotSupportedError') return null;
+          throw error;
+        }
+      }, { algName: alg.name });
+
+      if (spkiArray === null) {
+        test.skip(true, `${alg.name} not natively supported in this browser version.`);
+        return;
+      }
+
+      const spkiBytes = new Uint8Array(spkiArray);
+      const oid = ML_KEM_OIDS[alg.k];
+      
+      expect(oid).toBeDefined();
+      
+      const rawKey = unwrapSPKI(spkiBytes);
+      const rewrappedSpki = wrapSPKI(oid, rawKey);
+      
+      expect(rewrappedSpki).toEqual(spkiBytes);
+    });
+  }
+
+  const DSA_ALGS = [
+    { name: 'ML-DSA-44', k: 4 },
+    { name: 'ML-DSA-65', k: 6 },
+    { name: 'ML-DSA-87', k: 8 },
+  ];
+
+  for (const alg of DSA_ALGS) {
+    test(`Native ${alg.name} SPKI can be unwrapped and re-wrapped to match exactly`, async ({ page }) => {
+      const spkiArray = await page.evaluate(async ({ algName }) => {
+        try {
+          const kp = await window.crypto.subtle.generateKey(
+            { name: algName } as any,
+            true,
+            ['sign', 'verify'] as any
+          );
+          const spkiBuffer = await window.crypto.subtle.exportKey('spki', kp.publicKey);
+          return Array.from(new Uint8Array(spkiBuffer as ArrayBuffer));
+        } catch (error) {
+          if ((error as Error).name === 'NotSupportedError') return null;
+          throw error;
+        }
+      }, { algName: alg.name });
+
+      if (spkiArray === null) {
+        test.skip(true, `${alg.name} not natively supported in this browser version.`);
+        return;
+      }
+
+      const spkiBytes = new Uint8Array(spkiArray);
+      const oid = ML_DSA_OIDS[alg.k];
+      
+      expect(oid).toBeDefined();
+      
+      const rawKey = unwrapSPKI(spkiBytes);
+      const rewrappedSpki = wrapSPKI(oid, rawKey);
+      
+      expect(rewrappedSpki).toEqual(spkiBytes);
+    });
+  }
+});

--- a/test/webcrypto-smoke.test.ts
+++ b/test/webcrypto-smoke.test.ts
@@ -1,0 +1,190 @@
+import { test, expect } from '@playwright/test';
+
+test('debug: print browser version', async ({ browser }) => {
+  console.log(`Running Chromium Engine Version: ${browser.version()}`);
+});
+
+test('WebCrypto ML-KEM-768 is fully enabled and functional', async ({ page }) => {
+  await test.step('0. Navigate to a Secure Context', async () => {
+    // 1. Intercept network requests to a fake localhost address
+    await page.route('http://localhost:9999/', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<html><body>Mocked Secure Context</body></html>',
+      });
+    });
+
+    // 2. Navigate there so Chromium enables window.crypto.subtle
+    await page.goto('http://localhost:9999/');
+  });
+
+  await test.step('1. Ensure SubtleCrypto is available', async () => {
+    const hasSubtle = await page.evaluate(() => {
+      return window.crypto && window.crypto.subtle !== undefined;
+    });
+    expect(hasSubtle, 'window.crypto.subtle should be defined').toBeTruthy();
+  });
+
+  await test.step('2. Generate ML-KEM-768 KeyPair', async () => {
+    const keyGenState = await page.evaluate(async () => {
+      try {
+        // Generate keys and save them to the global window object for subsequent steps
+        const kp = await window.crypto.subtle.generateKey(
+          { name: 'ML-KEM-768' },
+          true,
+          ['encapsulateBits', 'decapsulateBits'] // Draft spec usages for KEMs
+        );
+
+        (window as any).pqcKeyPair = kp;
+
+        return {
+          success: true,
+          pubAlgName: kp.publicKey.algorithm.name,
+          privAlgName: kp.privateKey.algorithm.name,
+        };
+      } catch (error) {
+        return { success: false, error: (error as Error).name };
+      }
+    });
+
+    // If this fails, the PQC flag isn't working or the algorithm name is rejected
+    expect(keyGenState.success, `Key generation failed: ${keyGenState.error}`).toBe(true);
+    expect(keyGenState.pubAlgName).toBe('ML-KEM-768');
+    expect(keyGenState.privAlgName).toBe('ML-KEM-768');
+  });
+
+  await test.step('3. Encapsulate a shared secret against the Public Key', async () => {
+    const encapsState = await page.evaluate(async () => {
+      try {
+        // Cast subtle to any because standard TypeScript DOM types lack KEM methods currently
+        const subtleAny = window.crypto.subtle as any;
+        const kp = (window as any).pqcKeyPair;
+
+        const { sharedKey, ciphertext } = await subtleAny.encapsulateBits(
+          { name: 'ML-KEM-768' },
+          kp.publicKey
+        );
+
+        // Save outputs to window for the decapsulation step
+        (window as any).pqcCiphertext = ciphertext;
+        (window as any).pqcSharedKey = sharedKey;
+
+        return {
+          success: true,
+          sharedKeyByteLength: sharedKey.byteLength,
+          ciphertextByteLength: ciphertext.byteLength,
+        };
+      } catch (error) {
+        return { success: false, error: (error as Error).name };
+      }
+    });
+
+    expect(encapsState.success, `Encapsulation failed: ${encapsState.error}`).toBe(true);
+
+    // ML-KEM shared secrets are always 256-bit (32 bytes)
+    expect(encapsState.sharedKeyByteLength).toBe(32);
+
+    // ML-KEM-768 ciphertext is 1088 bytes according to FIPS 203 draft
+    expect(encapsState.ciphertextByteLength).toBe(1088);
+  });
+
+  await test.step('4. Decapsulate the ciphertext using the Private Key', async () => {
+    const decapsState = await page.evaluate(async () => {
+      try {
+        const subtleAny = window.crypto.subtle as any;
+        const kp = (window as any).pqcKeyPair;
+        const ciphertext = (window as any).pqcCiphertext;
+        const originalSharedKey = (window as any).pqcSharedKey;
+
+        // The receiver uses their private key to unpack the ciphertext
+        const decapsulatedKey = await subtleAny.decapsulateBits(
+          { name: 'ML-KEM-768' },
+          kp.privateKey,
+          ciphertext
+        );
+
+        // Compare the bytes to ensure both parties ended up with the identical secret
+        const originalBytes = new Uint8Array(originalSharedKey);
+        const decapsulatedBytes = new Uint8Array(decapsulatedKey);
+
+        const isMatch =
+          originalBytes.length === decapsulatedBytes.length &&
+          originalBytes.every((val, i) => val === decapsulatedBytes[i]);
+
+        return { success: true, isMatch };
+      } catch (error) {
+        return { success: false, error: (error as Error).name };
+      }
+    });
+
+    expect(decapsState.success, `Decapsulation failed: ${decapsState.error}`).toBe(true);
+    expect(
+      decapsState.isMatch,
+      'The decapsulated key must exactly match the encapsulated key'
+    ).toBe(true);
+  });
+});
+
+test('debug: print active chromium flags via CDP', async ({ browser }) => {
+  // 1. Open a direct DevTools Protocol session with the browser engine
+  const session = await browser.newBrowserCDPSession();
+
+  // 2. Ask Chromium for the exact arguments it was launched with
+  const result = await session.send('Browser.getBrowserCommandLine');
+
+  console.log('Active Command Line Arguments:');
+  console.log(result.arguments); // This prints the array of active flags
+
+  // 3. Verify our experimental flag made it into the launch sequence
+  expect(result.arguments).toContain('--enable-features=WebCryptoPQC');
+});
+
+test('spy on Web Crypto generateKey call', async ({ page }) => {
+  // 1. Array to hold the intercepted calls in our Node environment
+  const cryptoCalls: any[] = [];
+
+  // 2. Expose a function so the browser can send data back to Playwright
+  await page.exposeFunction('reportCryptoCall', (algorithm: any) => {
+    cryptoCalls.push(algorithm);
+  });
+
+  // 3. Inject a script before the page loads to wrap the native API
+  await page.addInitScript(() => {
+    const originalGenerateKey = window.crypto.subtle.generateKey.bind(window.crypto.subtle);
+
+    // @ts-ignore
+    window.crypto.subtle.generateKey = async function (algorithm, extractable, keyUsages) {
+      window.reportCryptoCall(algorithm);
+      return originalGenerateKey(algorithm, extractable, keyUsages);
+    };
+  });
+
+  // 4. FIX: Mock the route so we don't depend on a live server running on port 3000
+  // This satisfies both the Secure Context constraint and the page navigation
+  await page.route('https://pqc-test.local', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: '<html><body><h1>PQC Testing Sandbox</h1></body></html>',
+    });
+  });
+
+  // Navigate to our secure, mocked domain
+  await page.goto('https://pqc-test.local');
+
+  // 5. Trigger the code right inside the browser context
+  await page.evaluate(async () => {
+    // This executes inside the browser, triggering our spy!
+    await window.crypto.subtle.generateKey(
+      { name: 'ML-KEM-768' },
+      true,
+      // FIX: Use the KEM-specific usages mandated by the WebCrypto spec
+      ['encapsulateBits', 'decapsulateBits']
+    );
+  });
+
+  // 6. Assert! Verify your spy caught the execution
+  expect(cryptoCalls.length).toBeGreaterThan(0);
+  expect(cryptoCalls[0].name).toBe('ML-KEM-768');
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,6 @@
     "rootDir": "src",
     "outDir": "."
   },
-  "include": [
-    "src"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Note: This PR is stacked on top of #45 . Please review and merge that one first.

Fixes #43 

 ## Native WebCrypto PQC integration with separate TypeScript fallback API

This PR introduces native WebCrypto support for Post-Quantum Cryptography (PQC) algorithms (ML-KEM, ML-DSA, and X-Wing), while preserving the pure TypeScript implementation. An additional API enables TS as a reliable fallback, when explicitly used.

  ### Key Changes

  • Native WebCrypto Wrappers (src/webcrypto.ts): Implements standard wrappers around the browser's SubtleCrypto API to expose native PQC algorithms under the unified AsyncKEM and AsyncDSA interfaces.
  • Opportunistic Fallback Mechanism (src/webcrypto_with_fallback.ts): Introduces a hybrid module that probes the environment for native WebCrypto support upon initialization. It delegates operations to the native
  backend when supported, and falls back to the pure TypeScript implementation when native support is missing or when using deterministic inputs (e.g., keygen with a specific seed).
  • SPKI Utilities (src/utils.ts): Adds unwrapSPKI and wrapSPKI ASN.1 DER encoding/decoding helpers. These are required to dynamically convert raw public keys into the SPKI formats expected by native WebCrypto APIs.
  • Integration Testing (test/): Adds comprehensive Playwright integration tests to validate the hybrid fallback logic, verify that native WebCrypto SPKI formats map correctly to pure TS formats, and ensure
  interoperability between the implementations.

  ### Design Considerations

* This change has kept to request in #43 to keep the WebCrypto API usage in a separate, swappable API.
* It also includes an API variant `webcrypto_with_fallback.ts` that allows the same one-line change for library consumers to use an API that prioritizes WebCrypto *when available* and falls back to the TS impl otherwise. This behavior is likely to be the most desired by library consumers (including my team at Google) in the near term until broad rollout of PQC WebCrypto in browsers, then consumers will likely migrate to pure the pure WebCrypto API for security.