### PR TITLE
Fix zeroization on decapsulate error, SLH-DSA ACVP coverage, and a stale example

### DIFF
--- a/src/hybrid.ts
+++ b/src/hybrid.ts
@@ -514,8 +514,13 @@ export function combineKEMS(
     decapsulate(ct: TArg<Uint8Array>, seed: TArg<Uint8Array>) {
       const cts = ctCoder.decode(ct);
       const { publicKey, secretKey } = keys.expandDecapsulationKey(seed);
-      const sharedSecret = rawKems.map((i, j) => i.decapsulate(cts[j], secretKey[j]));
+      const sharedSecret: Uint8Array[] = [];
       try {
+        // Child decapsulate() is inside the try: it can throw on an attacker-supplied ciphertext
+        // (e.g. a low-order X25519 point), and by then the expanded child secret keys — plus any
+        // child shared secrets already produced — are live and must still be wiped.
+        for (let i = 0; i < rawKems.length; i++)
+          sharedSecret.push(rawKems[i].decapsulate(cts[i], secretKey[i]));
         // Detach the decapsulation result before cleanup: the combiner may hand back one of the
         // child shared-secret buffers, and those temporary buffers are zeroized below.
         return copyBytes(rawCombiner(publicKey, cts, sharedSecret));

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import {
 } from '@noble/post-quantum/falcon.js';
 import {
   ml_kem768_x25519, ml_kem768_p256, ml_kem1024_p384,
-  KitchenSink_ml_kem768_x25519, XWing,
+  KitchenSink_ml_kem768_x25519,
   QSF_ml_kem768_p256, QSF_ml_kem1024_p384,
 } from '@noble/post-quantum/hybrid.js';
 ```

--- a/src/ml-kem.ts
+++ b/src/ml-kem.ts
@@ -399,8 +399,11 @@ const genKPKE = (opts_: TArg<KyberOpts>) => {
       // tmp += sk[i] * u[i]
       for (let i = 0; i < K; i++) polyAdd(tmp, MultiplyNTTs(sk[i], crystals.NTT.encode(u[i])));
       polySub(v, crystals.NTT.decode(tmp)); // w = v' - tmp
-      cleanBytes(tmp, sk, u);
-      return poly1.encode(v) as TRet<Uint8Array>;
+      // `v` now holds w, from which the plaintext is just a 1-bit threshold away, so wipe it too.
+      // encode() allocates its own buffer, so the returned bytes do not alias `v`.
+      const res = poly1.encode(v) as TRet<Uint8Array>;
+      cleanBytes(tmp, sk, u, v);
+      return res;
     },
   };
 };

--- a/test/acvp.test.ts
+++ b/test/acvp.test.ts
@@ -298,7 +298,7 @@ describe('AVCP', () => {
               const ctx = t.p.context ? hexx(t.p.context) : undefined;
               if (g.info.p.preHash === 'preHash') {
                 const hash = HASHES[t.p.hashAlg];
-                if (checkStrength(hash) < slhdsa.securityLevel) return;
+                if (checkStrength(hash) < slhdsa.securityLevel) continue;
                 valid = slhdsa
                   .prehash(hash)
                   .verify(hexx(t.p.signature), hexx(t.p.message), hexx(t.p.pk), { context: ctx });

--- a/test/hybrid.test.ts
+++ b/test/hybrid.test.ts
@@ -248,6 +248,34 @@ describe('Hybrids', () => {
       }
     );
   });
+  it('combineKEMS/decapsulate-cleanup-on-child-decapsulate-throw', () => {
+    // A child decapsulate() can throw on an attacker-supplied ciphertext, so the expanded child
+    // secret keys and any already-produced child shared secrets must still be wiped.
+    const expanded: Uint8Array[] = [Uint8Array.of(1, 1), Uint8Array.of(2, 2)];
+    const firstSharedSecret = Uint8Array.of(9, 9);
+    const kem = (secretKey: Uint8Array, ss: Uint8Array | undefined) => ({
+      lengths: { seed: 2, secretKey: 2, publicKey: 1, cipherText: 1, msg: 2 },
+      keygen: (_seed?: Uint8Array) => ({ secretKey, publicKey: Uint8Array.of(1) }),
+      getPublicKey: (_secretKey: Uint8Array) => Uint8Array.of(1),
+      encapsulate: () => ({ sharedSecret: Uint8Array.of(1, 1), cipherText: Uint8Array.of(1) }),
+      decapsulate: () => {
+        if (ss === undefined) throw new Error('bad ciphertext');
+        return ss;
+      },
+    });
+    const hybrid = combineKEMS(
+      undefined,
+      2,
+      (seed, _len) => seed,
+      () => Uint8Array.of(0, 0),
+      kem(expanded[0], firstSharedSecret) as any,
+      kem(expanded[1], undefined) as any
+    );
+    throws(() => hybrid.decapsulate(Uint8Array.of(1, 1), Uint8Array.of(1, 2, 3, 4)), /bad ciphertext/);
+    // Both expanded child secret keys, and the shared secret the first child already returned,
+    // must be zeroized despite the throw.
+    eql(Array.from(firstSharedSecret), [0, 0]);
+  });
   it('combineSigners/keygen-cleanup-on-child-keygen-throw', () => {
     const seen: Uint8Array[] = [];
     const ok = {


### PR DESCRIPTION
Four independent fixes found while auditing the library. Each is a separate commit, so any one can be dropped.

None of these is exploitable on its own — no key recovery, no forgery, no plaintext disclosure — which is why this is a public PR rather than an email to the address in `SECURITY.md`. Three are hygiene/coverage, one is a doc fix.

---

### 1. `hybrid.ts` — child secrets survive a throwing decapsulation

`combineKEMS.decapsulate` called the child `decapsulate()` **outside** the `try`:

```js
const sharedSecret = rawKems.map((i, j) => i.decapsulate(cts[j], secretKey[j]));
try { ... } finally { cleanBytes(secretKey, sharedSecret); }
```

So a throw skipped the cleanup that the `finally`'s own comment promises to do "even on errors", stranding the expanded child secret keys and any child shared secrets already produced.

The throw is reachable from an attacker-supplied ciphertext: a low-order X25519 point in `ct_X` makes `ml_kem768_x25519.decapsulate` throw from inside the child call (`invalid private or public key received`). `encapsulate()` twenty lines above already accumulates inside the `try` for exactly this reason; this makes `decapsulate` match.

Adds `combineKEMS/decapsulate-cleanup-on-child-decapsulate-throw`, alongside the existing `combineSigners/keygen-cleanup-on-child-keygen-throw`. **Verified it fails without the fix and passes with it.**

### 2. `ml-kem.ts` — decrypted message polynomial left unwiped

In `K-PKE.decrypt`, after `polySub` the polynomial `v` holds `w`, and the plaintext is one 1-bit threshold away — `poly1.encode(v)` is literally that step. `cleanBytes` wiped `tmp`, `sk` and `u`, but not `v`. Note `u` is decoded from the public ciphertext and needs no wiping, while `decapsulate` deliberately wipes the same plaintext in the byte array it decodes into, so the intent is clear.

`encode()` allocates its own buffer, so the returned bytes do not alias `v`.

### 3. `test/acvp.test.ts` — SLH-DSA sigVer silently stops early

The weak-prehash guard used `return` instead of `continue`:

```js
if (checkStrength(hash) < slhdsa.securityLevel) return;   // ML-DSA siblings use continue
```

It sits inside both the group loop and the vector loop of the `sigVer` test, so the first vector whose hash is below the parameter set's security level ended the **whole test** — every later vector, in every later group and parameter set, went unrun while the suite still reported green. `HASHES` contains SHA2-224, SHA3-224 and SHA2-512/224, all 112-bit by `checkStrength`, so the guard is reachable at every security level. The two ML-DSA equivalents already use `continue`.

The `sigGen` counterpart at line 338 is deliberately left alone: `describe('sigGen')` builds one `it()` per vector at describe time, so its `return` skips exactly that vector and is correct as written (`continue` there would not even parse).

### 4. `index.ts` — example imports an export that doesn't exist

The module example imports `XWing` from `hybrid.js`. There is no such export, and `README.md` says so outright: "There is no separate `XWing` alias." Copying the example failed at import.

---

### Testing

`npx tsc --noEmit` clean. Green locally: `basic` 20, `hybrid` 42 (including the new test), `wycheproof` 15, `falcon` 27.

The new hybrid test was checked both ways — it fails against unpatched `hybrid.ts` and passes with the fix.

One gap worth stating plainly: I could not run `acvp.test.ts` itself, because the `acvp-vectors` submodule did not finish fetching here. Change 3 is therefore reasoned from the code structure and from the two ML-DSA guards that already use `continue`, not from an observed run. It is a one-word change and CI will exercise it.
